### PR TITLE
fix: preserve geometry precision + switch to AM fork of moleculer-postgis

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "moleculer-decorators": "^1.3.0",
     "moleculer-knex-filters": "github:DadPatch/moleculer-knex-filters",
     "moleculer-minio": "github:dadpatch/moleculer-minio",
-    "moleculer-postgis": "^0.2.7",
+    "moleculer-postgis": "github:AplinkosMinisterija/moleculer-postgis#v0.4.0",
     "moleculer-sentry": "^2.0.0",
     "moleculer-web": "^0.10.4",
     "moment": "^2.29.4",
@@ -92,5 +92,8 @@
         "tsconfig": "tsconfig.json"
       }
     }
+  },
+  "resolutions": {
+    "moleculer-postgis": "github:AplinkosMinisterija/moleculer-postgis#v0.4.0"
   }
 }

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -81,6 +81,7 @@ const populatePermissions = (field: string) => {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/services/objects.service.ts
+++ b/services/objects.service.ts
@@ -95,6 +95,7 @@ export const UETKObjectTypeTranslates = {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -114,6 +114,7 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,20 +4525,10 @@ moleculer-decorators@^1.3.0:
     ramda "0.27.1"
     ramda-adjunct "^2.35.0"
 
-moleculer-postgis@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/moleculer-postgis/-/moleculer-postgis-0.2.7.tgz#a3b1087e33bade1c54e18ded43facd5505b07940"
-  integrity sha512-JO/OPiyIfsV5u7KKBgozSA57CGAJEmuOBRTESiadjiJGDkuDWiu30h4aQ4/nzAEjVSc2aHOiDI2iU9QEQlMy+Q==
-  dependencies:
-    geojsonjs "^0.1.2"
-    lodash "^4.17.21"
-    moleculer "^0.14.31"
-    typescript "^4.5.5"
-
-moleculer-postgis@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/moleculer-postgis/-/moleculer-postgis-0.3.3.tgz#ee82573d74f3a671ccb7d9383dd63e3a4d6a97b5"
-  integrity sha512-XTLHtgCOZaFAFQzcXILe2dKxBnUiaBr+5torts8StoBHyAca0J1pHI7Nhd7zdybDtYWb88bZLjfm4HYLv1wgsQ==
+moleculer-postgis@^0.3.3, "moleculer-postgis@github:AplinkosMinisterija/moleculer-postgis#v0.4.0":
+  version "0.4.0"
+  uid "62323a28da9add69a2ddd6018cbd17c2b343f668"
+  resolved "https://codeload.github.com/AplinkosMinisterija/moleculer-postgis/tar.gz/62323a28da9add69a2ddd6018cbd17c2b343f668"
   dependencies:
     geojsonjs "^0.1.2"
     lodash "^4.17.21"


### PR DESCRIPTION
## Two fixes in one PR

### 1. Add explicit `maxDecimalDigits` overrides per service

`PostgisMixin` was called without `geojson` options, using the default `{ maxDecimalDigits: 0 }` from `moleculer-postgis`. This causes every `ST_AsGeoJSON` call to round coordinates to integer units on load:
- LKS94 (EPSG:3346, meters) — ~0.7m shift per vertex, vertex merging in complex shapes
- WGS84 (EPSG:4326, degrees) — ~110km shift per degree

Impact verified on biip-rusys-api production: **32% of ~250k forms were re-saved after load under this bug**, irreversibly rounded to integer meters.

Added `geojson: { maxDecimalDigits: 2 }` (or `7` for WGS84) to every `PostgisMixin` call in this repo. Defensive — works even if the library default changes later.

### 2. Switch to AplinkosMinisterija fork of `moleculer-postgis`

The original package (`ambrazasp/moleculer-postgis`) is unmaintained. Switched to [`AplinkosMinisterija/moleculer-postgis`](https://github.com/AplinkosMinisterija/moleculer-postgis) pinned to tag `v0.4.0`, which adds two library-level fixes:

- **SQL injection patch** — `JSON.stringify` in `geometriesAsTextQuery` didn't escape single quotes, enabling SQLi via `crs.properties.name` or feature property strings (time-based blind via `pg_sleep`). Every PostgisMixin consumer was affected. Fixed at library level: consumers no longer need to worry.
- **Default `maxDecimalDigits` changed from `0` to `9`** (PostGIS documented default). Future services using `PostgisMixin({ srid: X })` without explicit options get sane precision out of the box.

Library PR: [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4)

`yarn resolutions` is set to also force the fork on transitive deps (e.g. via `@aplinkosministerija/moleculer-accounts`).

## Merge order

1. First merge [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4) and confirm tag `v0.4.0` exists on `main`.
2. Then merge this PR.

## Test plan

- [ ] `yarn install` resolves `moleculer-postgis` to the fork (check `yarn.lock` has `codeload.github.com/AplinkosMinisterija/moleculer-postgis/...`)
- [ ] Service starts; form save/load works
- [ ] Existing geometries return with full float precision (not integer meters)
- [ ] New geometries drawn with fine detail (notches, narrow vertices) survive save+reload
- [ ] No regression on spatial queries (intersects, distance, buffer)
