### PR TITLE
Issue #4: extract PDF map page header + river label

### DIFF
--- a/templates/request.ejs
+++ b/templates/request.ejs
@@ -134,6 +134,36 @@
 
         <% if (item.screenshot) { %>
           <div class="page-break"></div>
+          <div class="flex items-center justify-center">
+            <div>
+              <img src="https://s3.biip.lt/uetk-wp/app/uploads/AAA-Zenklas-RGB-1-300x300.png" class="w-16"/>
+            </div>
+            <div class="flex flex-col items-center w-full mr-20 text-center">
+              <p class="font-bold text-2xl">APLINKOS APSAUGOS AGENTŪRA</p>
+              <p>
+                Biudžetinė įstaiga, A. Juozapavičiaus g. 9, LT-09311 Vilnius, tel.
+                <a href="tel:+37068292653">+370 682 92653</a>, el.p. <a href="mailto:aaa@gamta.lt">aaa@gamta.lt</a>, <a href="https://aaa.lrv.lt">https://aaa.lrv.lt</a>.
+              </p>
+              <p>
+                Duomenys kaupiami ir saugojami Juridinių asmenų registre, kodas
+                188784898
+              </p>
+            </div>
+          </div>
+          <hr />
+          <div class="flex flex-col items-center">
+            <p>LIETUVOS RESPUBLIKOS UPIŲ, EŽERŲ IR TVENKINIŲ KADASTRO ŽEMĖLAPIO IŠTRAUKA</p>
+            <p>Išrašo unikalus numeris <b><%= id %></b>, suformavimo data <b><%= formatDate(new Date()) %></b></p>
+          </div>
+          <hr />
+          <% if (item.category === 'RIVER') { %>
+            <div class="flex flex-col items-center my-4">
+              <p class="font-bold text-xl"><%= item.extendedData?.pavadinimas || item.name || '' %></p>
+              <% if (item.extendedData?.kadastroId || item.cadastralId) { %>
+                <p>Identifikavimo kodas: <b><%= item.extendedData?.kadastroId || item.cadastralId %></b></p>
+              <% } %>
+            </div>
+          <% } %>
           <img src="<%= item.screenshot %>" class="w-full my-4" />
         <% } %>
         


### PR DESCRIPTION
## Summary
Addresses parts 2 and 3 of issue #4 (PDF extract — map page changes):

- **Map page header.** When a screenshot is included, the new page now opens with the AAA preamble (logo + agency contact) and the inscription **LIETUVOS RESPUBLIKOS UPIŲ, EŽERŲ IR TVENKINIŲ KADASTRO ŽEMĖLAPIO IŠTRAUKA**, followed by the extract unique number and generation date — same visual style used on the data cover page.
- **River label above map.** For `RIVER` items the river name (`extendedData.pavadinimas`) and identification code (`extendedData.kadastroId`) are rendered above the screenshot so the reader sees which river the depicted geometry represents.

## Out of scope (separate PR)
Part 1 of the issue — moving the legend (Sutartiniai ženklai) under the map and limiting it to visible layers — requires changes in `biip-maps-web` (the screenshot source), so it will land as a separate PR there.

The "upstream rivers with codes" sub-bullet is also deferred — it requires querying the river hierarchy that isn't currently exposed; will scope separately if still wanted.

## Test plan
- [ ] Generate a request extract PDF for a single river — verify map opens on a fresh page with logo, agency block, preamble, extract number/date, and river name + code.
- [ ] Generate an extract for a non-river object (lake, pond, fish pass) — verify the map page shows the cover header but no river label.
- [ ] Generate a multi-object extract — verify each object's map page renders the cover correctly.
- [ ] Confirm the existing data pages and footer are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)