### PR TITLE
Issue #1: auto-generate extract PDF when admin approves form

### DIFF
--- a/database/migrations/20260505120000_addGeneratedFileToForms.js
+++ b/database/migrations/20260505120000_addGeneratedFileToForms.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('forms', (table) => {
+      table.text('generatedFile');
+    })
+    .raw(`ALTER TYPE form_history_type ADD VALUE IF NOT EXISTS 'FILE_GENERATED'`);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('forms', (table) => {
+    table.dropColumn('generatedFile');
+  });
+};

--- a/services/forms.histories.service.ts
+++ b/services/forms.histories.service.ts
@@ -16,6 +16,7 @@ export const FormHistoryTypes = {
   REJECTED: 'REJECTED',
   RETURNED: 'RETURNED',
   APPROVED: 'APPROVED',
+  FILE_GENERATED: 'FILE_GENERATED',
 };
 
 @Service({

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -18,7 +18,11 @@ import {
   NOTIFY_ADMIN_EMAIL,
   TENANT_FIELD,
 } from '../types';
-import { emailCanBeSent, notifyOnFormUpdate } from '../utils/mails';
+import {
+  emailCanBeSent,
+  notifyOnFileGeneratedForForm,
+  notifyOnFormUpdate,
+} from '../utils/mails';
 import { UserAuthMeta } from './api.service';
 import { FormHistoryTypes } from './forms.histories.service';
 import { UETKObject, UETKObjectType } from './objects.service';
@@ -34,6 +38,8 @@ export interface Form extends BaseModelInterface {
   cadastralId: string | number;
   type: string;
   objectType: string;
+  generatedFile?: string;
+  tenant?: number | Tenant;
 }
 
 export const FormStatus = {
@@ -193,6 +199,8 @@ const populatePermissions = (field: string) => {
         populate: populatePermissions('validate'),
       },
 
+      generatedFile: 'string',
+
       ...TENANT_FIELD,
 
       ...COMMON_FIELDS,
@@ -289,6 +297,52 @@ export default class FormsService extends moleculer.Service {
       types: ALL_FILE_TYPES,
       folder,
     });
+  }
+
+  @Action({
+    params: {
+      id: 'number',
+      url: 'string',
+    },
+  })
+  saveGeneratedPdf(ctx: Context<{ id: number; url: string }>) {
+    const { id, url: generatedFile } = ctx.params;
+
+    return this.updateEntity(ctx, {
+      id,
+      generatedFile,
+    });
+  }
+
+  @Action({
+    params: {
+      id: {
+        type: 'number',
+        convert: true,
+      },
+    },
+    rest: 'POST /:id/generate',
+    timeout: 0,
+  })
+  async generatePdf(ctx: Context<{ id: number }>) {
+    const flow: any = await ctx.call('jobs.forms.initiatePdfGenerate', {
+      id: ctx.params.id,
+    });
+
+    return {
+      generating: !!flow?.job?.id,
+    };
+  }
+
+  @Method
+  async generatePdfIfNeeded(form: Form) {
+    if (!form?.id) return;
+    if (form.status !== FormStatus.APPROVED) return;
+    if (form.generatedFile) return;
+    if (!form.cadastralId) return;
+
+    this.broker.call('forms.generatePdf', { id: form.id });
+    return form;
   }
 
   @Method
@@ -466,7 +520,37 @@ export default class FormsService extends moleculer.Service {
         type: typesByStatus[form.status],
       });
 
+      await this.generatePdfIfNeeded(form);
       await this.sendNotificationOnStatusChange(form);
+    }
+
+    if (
+      prevForm?.generatedFile !== form.generatedFile &&
+      !!form.generatedFile
+    ) {
+      await ctx.call(
+        'forms.histories.create',
+        {
+          form: form.id,
+          type: FormHistoryTypes.FILE_GENERATED,
+        },
+        { meta: null }
+      );
+
+      if (emailCanBeSent()) {
+        const user: User = await ctx.call('users.resolve', {
+          id: form.createdBy,
+          scope: USERS_DEFAULT_SCOPES,
+        });
+
+        if (user?.email) {
+          notifyOnFileGeneratedForForm(
+            user.email,
+            form.id,
+            user.type === UserType.ADMIN
+          );
+        }
+      }
     }
   }
 

--- a/services/jobs.forms.service.ts
+++ b/services/jobs.forms.service.ts
@@ -1,0 +1,223 @@
+'use strict';
+
+import moleculer, { Context } from 'moleculer';
+import { Action, Method, Service } from 'moleculer-decorators';
+import moment from 'moment';
+import BullMqMixin from '../mixins/bullmq.mixin';
+import { FILE_TYPES, throwNotFoundError } from '../types';
+import {
+  addLeadingZeros,
+  getRequestSecret,
+  getTemplateHtml,
+  roundNumber,
+  toMD5Hash,
+  toReadableStream,
+} from '../utils';
+import { AuthType } from './api.service';
+import { Form } from './forms.service';
+import { Tenant } from './tenants.service';
+import { User } from './users.service';
+
+@Service({
+  name: 'jobs.forms',
+  mixins: [BullMqMixin],
+  settings: {
+    bullmq: {
+      worker: { concurrency: 5 },
+      job: {
+        attempts: 5,
+        failParentOnFailure: true,
+        backoff: 1000,
+      },
+    },
+  },
+})
+export default class JobsFormsService extends moleculer.Service {
+  @Action({
+    queue: true,
+    params: { id: 'number' },
+    timeout: 0,
+  })
+  async generateAndSavePdf(ctx: Context<{ id: number }>) {
+    const { id } = ctx.params;
+    const { job } = ctx.locals;
+
+    const form: Form = await ctx.call('forms.resolve', {
+      id,
+      populate: 'createdBy,tenant',
+    });
+
+    const childrenValues = await job.getChildrenValues();
+    const screenshotsByHash: any = Object.values(childrenValues).reduce(
+      (acc: any, item: any) => ({ ...acc, [item.hash]: item.url }),
+      {}
+    );
+
+    const screenshotsHash = toMD5Hash(
+      `id=${id}&date=${moment().format('YYYYMMDDHHmmsss')}`
+    );
+    await this.broker.cacher.set(
+      `screenshots.${screenshotsHash}`,
+      screenshotsByHash
+    );
+
+    const secret = getRequestSecret(form);
+
+    const footerHtml = getTemplateHtml('footer.ejs', {
+      id: addLeadingZeros(id),
+      date: moment(form.createdAt).format('YYYY-MM-DD'),
+    });
+
+    const pdf = await ctx.call('tools.makePdf', {
+      url: `${process.env.SERVER_HOST}/jobs/forms/${id}/html?secret=${secret}&skey=${screenshotsHash}`,
+      footer: footerHtml,
+    });
+
+    const folder = this.getFolderName(
+      form?.createdBy as any as User,
+      form?.tenant as Tenant
+    );
+
+    const result: any = await ctx.call(
+      'minio.uploadFile',
+      {
+        payload: toReadableStream(pdf),
+        folder,
+        isPrivate: true,
+        types: FILE_TYPES,
+      },
+      {
+        meta: {
+          mimetype: 'application/pdf',
+          filename: `israsas-forma-${form.id}.pdf`,
+        },
+      }
+    );
+
+    await ctx.call('forms.saveGeneratedPdf', { id, url: result.url });
+
+    return { job: job.id };
+  }
+
+  @Action({
+    params: { id: 'number' },
+    timeout: 0,
+  })
+  async initiatePdfGenerate(ctx: Context<{ id: number }>) {
+    const { id } = ctx.params;
+
+    const objects: any[] = await this.getFormObjectData(id);
+    if (!objects.length) return { job: null };
+
+    const params = new URLSearchParams({ screenshot: '1', preview: '1' });
+
+    function getUrl(p: URLSearchParams) {
+      const mapHost = process.env.MAPS_HOST || 'https://maps.biip.lt';
+      return `${mapHost}/uetk?${p.toString()}`;
+    }
+
+    const data = objects.map((item) => {
+      params.set('cadastralId', `${item.id}`);
+      return { url: getUrl(params), hash: item.hash };
+    });
+
+    const childrenJobs = data.map((item) => ({
+      params: { ...item, waitFor: '#image-canvas-0' },
+      name: 'jobs',
+      action: 'saveScreenshot',
+    }));
+
+    return this.flow(
+      ctx,
+      'jobs.forms',
+      'generateAndSavePdf',
+      { id },
+      childrenJobs
+    );
+  }
+
+  @Action({
+    params: {
+      id: { type: 'number', convert: true },
+      secret: 'string',
+      skey: { type: 'string', optional: true },
+    },
+    rest: 'GET /:id/html',
+    timeout: 0,
+    auth: AuthType.PUBLIC,
+  })
+  async getFormHtml(
+    ctx: Context<
+      { id: number; secret: string; skey: string },
+      { $responseType: string }
+    >
+  ) {
+    const { id, secret, skey: screenshotsRedisKey } = ctx.params;
+
+    const form: Form = await ctx.call('forms.resolve', {
+      id,
+      throwIfNotExist: true,
+    });
+
+    const secretToApprove = getRequestSecret(form);
+    if (!form?.id || !secret || secret !== secretToApprove) {
+      return throwNotFoundError('Invalid secret!');
+    }
+
+    const objects: any[] = await this.getFormObjectData(id);
+
+    let screenshotsByHash: any = {};
+    if (screenshotsRedisKey) {
+      screenshotsByHash = await this.broker.cacher.get(
+        `screenshots.${screenshotsRedisKey}`
+      );
+    }
+
+    ctx.meta.$responseType = 'text/html';
+
+    return getTemplateHtml('request.ejs', {
+      id: addLeadingZeros(id),
+      date: form.createdAt,
+      objects: objects.map((o) => ({
+        ...o,
+        screenshot: screenshotsByHash?.[o.hash] || '',
+      })),
+      formatDate: (date: string, format = 'YYYY-MM-DD') => {
+        if (!date?.toString()?.trim()) return;
+        const m = moment(date);
+        if (!m.isValid()) return;
+        return m.format(format);
+      },
+      roundNumber,
+      trimValue: (value?: string) => (!value ? '' : value?.trim()),
+      fullData: false,
+    });
+  }
+
+  @Method
+  getFolderName(user?: User, tenant?: Tenant) {
+    const tenantPath = tenant?.id || 'private';
+    const userPath = user?.id || 'user';
+
+    return `uploads/forms/${tenantPath}/${userPath}`;
+  }
+
+  @Method
+  async getFormObjectData(id: number) {
+    const form: Form = await this.broker.call('forms.resolve', { id });
+
+    if (!form?.cadastralId) return [];
+
+    const items: any[] = await this.broker.call('objects.find', {
+      query: { cadastralId: { $in: [form.cadastralId] } },
+      populate: 'extendedData',
+    });
+
+    return items.map((item) => ({
+      ...item,
+      screenshot: '',
+      id: item.cadastralId,
+      hash: toMD5Hash(`cadastralId=${item.cadastralId}`),
+    }));
+  }
+}

--- a/utils/mails.ts
+++ b/utils/mails.ts
@@ -115,3 +115,21 @@ export function notifyOnFileGenerated(
     },
   });
 }
+
+export function notifyOnFileGeneratedForForm(
+  email: string,
+  formId: number | string,
+  isAdmin: boolean = false
+) {
+  const path = isAdmin ? 'uetk/teikimo-anketos' : 'duomenu-teikimas';
+
+  return client.sendEmailWithTemplate({
+    From: sender,
+    To: email.toLowerCase(),
+    TemplateId: 32594847,
+    TemplateModel: {
+      requestId: formId,
+      actionUrl: `${hostUrl(isAdmin)}/${path}/${formId}`,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
When an administrator approves a form (\`FormStatus.APPROVED\`) the system now automatically generates an extract PDF for the affected UETK object and emails the form's creator with a link to it. Mirrors the request-approval flow that already exists.

### Backend changes (this repo)
- **Migration** \`20260505120000_addGeneratedFileToForms\` — adds \`generatedFile\` column to \`forms\` and adds \`FILE_GENERATED\` to the \`form_history_type\` Postgres enum.
- **\`forms.service\`** — new \`generatedFile\` field on the entity + interface; new \`forms.generatePdf\` and \`forms.saveGeneratedPdf\` actions; new \`generatePdfIfNeeded\` method; the \`forms.updated\` event now triggers PDF generation on status→APPROVED and writes a \`FILE_GENERATED\` history entry + sends an email when \`generatedFile\` is set.
- **\`forms.histories.service\`** — \`FILE_GENERATED\` enum value.
- **\`jobs.forms.service\`** (new) — analogous to \`jobs.requests\`: \`initiatePdfGenerate\` chains a \`saveScreenshot\` BullMQ child job to \`generateAndSavePdf\`, which fetches HTML from \`getFormHtml\` (renders the same \`request.ejs\` template with a single-object array), wraps it via \`tools.makePdf\`, uploads to MinIO, and writes the URL back via \`forms.saveGeneratedPdf\`.
- **\`utils/mails.ts\`** — \`notifyOnFileGeneratedForForm\` reuses the existing Postmark template but points at the form page (admin: \`uetk/teikimo-anketos/:id\`, user: \`duomenu-teikimas/:id\`).

### Out of scope
\`FormType.NEW\` (new object registration) without a cadastralId is skipped — there's no UETK object to generate an extract for until the registration completes externally. Wire that in once the new-object→cadastralId assignment exists.

## Test plan
- [ ] Run migrations on a fresh DB; verify \`generated_file\` column exists on \`forms\` and \`form_history_type\` includes \`FILE_GENERATED\`.
- [ ] Submit an EDIT or REMOVE form for an existing object, approve as admin → verify \`generatedFile\` URL gets saved on the form, a \`FILE_GENERATED\` history entry appears, and (in production env) the user receives an email.
- [ ] Submit a NEW form (no cadastralId), approve → verify no PDF generation is attempted (status update + email still flow through).
- [ ] Open the generated PDF URL — verify it renders the same extract layout as request PDFs (single-object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)