### PR TITLE
Issue #3: assignee on requests/forms with admin assign action

### DIFF
--- a/database/migrations/20260505140000_addAssignedToOnRequestsAndForms.js
+++ b/database/migrations/20260505140000_addAssignedToOnRequestsAndForms.js
@@ -1,0 +1,27 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('requests', (table) => {
+      table.integer('assignedTo').unsigned();
+    })
+    .alterTable('forms', (table) => {
+      table.integer('assignedTo').unsigned();
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .alterTable('requests', (table) => {
+      table.dropColumn('assignedTo');
+    })
+    .alterTable('forms', (table) => {
+      table.dropColumn('assignedTo');
+    });
+};

--- a/database/migrations/20260505140000_addAssigneeOnRequestsAndForms.js
+++ b/database/migrations/20260505140000_addAssigneeOnRequestsAndForms.js
@@ -5,10 +5,10 @@
 exports.up = function (knex) {
   return knex.schema
     .alterTable('requests', (table) => {
-      table.integer('assignedTo').unsigned();
+      table.integer('assigneeId').unsigned();
     })
     .alterTable('forms', (table) => {
-      table.integer('assignedTo').unsigned();
+      table.integer('assigneeId').unsigned();
     });
 };
 
@@ -19,9 +19,9 @@ exports.up = function (knex) {
 exports.down = function (knex) {
   return knex.schema
     .alterTable('requests', (table) => {
-      table.dropColumn('assignedTo');
+      table.dropColumn('assigneeId');
     })
     .alterTable('forms', (table) => {
-      table.dropColumn('assignedTo');
+      table.dropColumn('assigneeId');
     });
 };

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -13,6 +13,7 @@ import {
   COMMON_FIELDS,
   COMMON_SCOPES,
   ContextMeta,
+  EndpointType,
   EntityChangedParams,
   FieldHookCallback,
   NOTIFY_ADMIN_EMAIL,
@@ -34,6 +35,7 @@ export interface Form extends BaseModelInterface {
   cadastralId: string | number;
   type: string;
   objectType: string;
+  assignedTo?: number | User;
 }
 
 export const FormStatus = {
@@ -193,6 +195,12 @@ const populatePermissions = (field: string) => {
         populate: populatePermissions('validate'),
       },
 
+      assignedTo: {
+        type: 'number',
+        columnType: 'integer',
+        populate: 'users.resolve',
+      },
+
       ...TENANT_FIELD,
 
       ...COMMON_FIELDS,
@@ -212,7 +220,10 @@ const populatePermissions = (field: string) => {
         if (profile?.id) {
           return { ...query, tenant: profile.id };
         } else if (user.type === UserType.USER) {
-          return { ...query, ...createdByUserQuery };
+          return {
+            ...query,
+            $or: [createdByUserQuery, { assignedTo: user.id }],
+          };
         }
 
         if (query.createdBy === user.id) {
@@ -291,6 +302,83 @@ export default class FormsService extends moleculer.Service {
     });
   }
 
+  @Action({
+    params: {
+      id: { type: 'number', convert: true },
+      assignedTo: { type: 'number', convert: true, optional: true },
+    },
+    rest: 'POST /:id/assign',
+    types: [EndpointType.ADMIN],
+  })
+  async assign(
+    ctx: Context<
+      { id: number; assignedTo?: number | null },
+      UserAuthMeta
+    >
+  ) {
+    const { id, assignedTo } = ctx.params;
+
+    const form: Form = await ctx.call('forms.resolve', {
+      id,
+      throwIfNotExist: true,
+    });
+
+    const previousAssignee = form.assignedTo
+      ? Number(form.assignedTo)
+      : null;
+    const nextAssignee = assignedTo ?? null;
+
+    if (previousAssignee === nextAssignee) return form;
+
+    const updated: Form = await this.updateEntity(ctx, {
+      id,
+      assignedTo: nextAssignee,
+    });
+
+    if (emailCanBeSent()) {
+      let object: Partial<UETKObject>;
+      if (updated.cadastralId) {
+        object = await ctx.call('objects.findOne', {
+          query: { cadastralId: updated.cadastralId },
+        });
+      } else {
+        object = { name: updated.objectName };
+      }
+
+      if (object?.name) {
+        if (nextAssignee) {
+          const assignee: User = await ctx.call('users.resolve', {
+            id: nextAssignee,
+            scope: USERS_DEFAULT_SCOPES,
+          });
+          if (assignee?.email) {
+            notifyOnFormUpdate(
+              assignee.email,
+              updated.status,
+              updated.id,
+              updated.type,
+              object.name,
+              object.cadastralId,
+              true
+            );
+          }
+        } else if (previousAssignee) {
+          notifyOnFormUpdate(
+            NOTIFY_ADMIN_EMAIL,
+            updated.status,
+            updated.id,
+            updated.type,
+            object.name,
+            object.cadastralId,
+            true
+          );
+        }
+      }
+    }
+
+    return updated;
+  }
+
   @Method
   validateStatus({ ctx, value, entity }: FieldHookCallback) {
     const { user, profile } = ctx.meta;
@@ -362,6 +450,16 @@ export default class FormsService extends moleculer.Service {
           form.status
         ),
       };
+    } else if (
+      form.assignedTo &&
+      Number(form.assignedTo) === Number(user.id)
+    ) {
+      return {
+        edit: false,
+        validate: [FormStatus.CREATED, FormStatus.SUBMITTED].includes(
+          form.status
+        ),
+      };
     }
 
     return invalid;
@@ -416,10 +514,21 @@ export default class FormsService extends moleculer.Service {
 
     if (!emailCanBeSent() || !object?.name) return;
 
-    // TODO: send email for admins / assignees.
     if ([FormStatus.CREATED, FormStatus.SUBMITTED].includes(form.status)) {
+      let recipientEmail = NOTIFY_ADMIN_EMAIL;
+
+      if (form.assignedTo) {
+        const assignee: User = await this.broker.call('users.resolve', {
+          id: form.assignedTo,
+          scope: USERS_DEFAULT_SCOPES,
+        });
+        if (assignee?.email) {
+          recipientEmail = assignee.email;
+        }
+      }
+
       return notifyOnFormUpdate(
-        NOTIFY_ADMIN_EMAIL,
+        recipientEmail,
         form.status,
         form.id,
         form.type,

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -35,7 +35,7 @@ export interface Form extends BaseModelInterface {
   cadastralId: string | number;
   type: string;
   objectType: string;
-  assignedTo?: number | User;
+  assignee?: number | User;
 }
 
 export const FormStatus = {
@@ -195,9 +195,10 @@ const populatePermissions = (field: string) => {
         populate: populatePermissions('validate'),
       },
 
-      assignedTo: {
+      assignee: {
         type: 'number',
         columnType: 'integer',
+        columnName: 'assigneeId',
         populate: 'users.resolve',
       },
 
@@ -222,7 +223,7 @@ const populatePermissions = (field: string) => {
         } else if (user.type === UserType.USER) {
           return {
             ...query,
-            $or: [createdByUserQuery, { assignedTo: user.id }],
+            $or: [createdByUserQuery, { assignee: user.id }],
           };
         }
 
@@ -303,36 +304,31 @@ export default class FormsService extends moleculer.Service {
   }
 
   @Action({
+    rest: 'POST /:id/assignee/:assignee?',
     params: {
       id: { type: 'number', convert: true },
-      assignedTo: { type: 'number', convert: true, optional: true },
+      assignee: { type: 'number', convert: true, optional: true },
     },
-    rest: 'POST /:id/assign',
     types: [EndpointType.ADMIN],
   })
-  async assign(
-    ctx: Context<
-      { id: number; assignedTo?: number | null },
-      UserAuthMeta
-    >
+  async setAssignee(
+    ctx: Context<{ id: number; assignee?: number }, UserAuthMeta>
   ) {
-    const { id, assignedTo } = ctx.params;
+    const { id, assignee } = ctx.params;
 
     const form: Form = await ctx.call('forms.resolve', {
       id,
       throwIfNotExist: true,
     });
 
-    const previousAssignee = form.assignedTo
-      ? Number(form.assignedTo)
-      : null;
-    const nextAssignee = assignedTo ?? null;
+    const previousAssignee = form.assignee ? Number(form.assignee) : null;
+    const nextAssignee = assignee ?? null;
 
     if (previousAssignee === nextAssignee) return form;
 
     const updated: Form = await this.updateEntity(ctx, {
       id,
-      assignedTo: nextAssignee,
+      assignee: nextAssignee,
     });
 
     if (emailCanBeSent()) {
@@ -347,13 +343,13 @@ export default class FormsService extends moleculer.Service {
 
       if (object?.name) {
         if (nextAssignee) {
-          const assignee: User = await ctx.call('users.resolve', {
+          const assigneeUser: User = await ctx.call('users.resolve', {
             id: nextAssignee,
             scope: USERS_DEFAULT_SCOPES,
           });
-          if (assignee?.email) {
+          if (assigneeUser?.email) {
             notifyOnFormUpdate(
-              assignee.email,
+              assigneeUser.email,
               updated.status,
               updated.id,
               updated.type,
@@ -451,8 +447,8 @@ export default class FormsService extends moleculer.Service {
         ),
       };
     } else if (
-      form.assignedTo &&
-      Number(form.assignedTo) === Number(user.id)
+      form.assignee &&
+      Number(form.assignee) === Number(user.id)
     ) {
       return {
         edit: false,
@@ -517,13 +513,13 @@ export default class FormsService extends moleculer.Service {
     if ([FormStatus.CREATED, FormStatus.SUBMITTED].includes(form.status)) {
       let recipientEmail = NOTIFY_ADMIN_EMAIL;
 
-      if (form.assignedTo) {
-        const assignee: User = await this.broker.call('users.resolve', {
-          id: form.assignedTo,
+      if (form.assignee) {
+        const assigneeUser: User = await this.broker.call('users.resolve', {
+          id: form.assignee,
           scope: USERS_DEFAULT_SCOPES,
         });
-        if (assignee?.email) {
-          recipientEmail = assignee.email;
+        if (assigneeUser?.email) {
+          recipientEmail = assigneeUser.email;
         }
       }
 

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -51,7 +51,7 @@ export interface Request extends BaseModelInterface {
   generatedFile: string;
   notifyEmail: string;
   tenant: number | Tenant;
-  assignedTo?: number | User;
+  assignee?: number | User;
   data?: {
     extended?: boolean;
   };
@@ -244,9 +244,10 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
 
       generatedFile: 'string',
 
-      assignedTo: {
+      assignee: {
         type: 'number',
         columnType: 'integer',
+        columnName: 'assigneeId',
         populate: 'users.resolve',
       },
 
@@ -290,7 +291,7 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
         } else if (user.type === UserType.USER) {
           return {
             ...query,
-            $or: [createdByUserQuery, { assignedTo: user.id }],
+            $or: [createdByUserQuery, { assignee: user.id }],
           };
         }
 
@@ -405,46 +406,43 @@ export default class RequestsService extends moleculer.Service {
   }
 
   @Action({
+    rest: 'POST /:id/assignee/:assignee?',
     params: {
       id: { type: 'number', convert: true },
-      assignedTo: { type: 'number', convert: true, optional: true },
+      assignee: { type: 'number', convert: true, optional: true },
     },
-    rest: 'POST /:id/assign',
     types: [EndpointType.ADMIN],
   })
-  async assign(
-    ctx: Context<
-      { id: number; assignedTo?: number | null },
-      UserAuthMeta
-    >
+  async setAssignee(
+    ctx: Context<{ id: number; assignee?: number }, UserAuthMeta>
   ) {
-    const { id, assignedTo } = ctx.params;
+    const { id, assignee } = ctx.params;
 
     const request: Request = await ctx.call('requests.resolve', {
       id,
       throwIfNotExist: true,
     });
 
-    const previousAssignee = request.assignedTo
-      ? Number(request.assignedTo)
+    const previousAssignee = request.assignee
+      ? Number(request.assignee)
       : null;
-    const nextAssignee = assignedTo ?? null;
+    const nextAssignee = assignee ?? null;
 
     if (previousAssignee === nextAssignee) return request;
 
     const updated: Request = await this.updateEntity(ctx, {
       id,
-      assignedTo: nextAssignee,
+      assignee: nextAssignee,
     });
 
     if (emailCanBeSent() && nextAssignee) {
-      const assignee: User = await ctx.call('users.resolve', {
+      const assigneeUser: User = await ctx.call('users.resolve', {
         id: nextAssignee,
         scope: USERS_DEFAULT_SCOPES,
       });
-      if (assignee?.email) {
+      if (assigneeUser?.email) {
         notifyOnRequestUpdate(
-          assignee.email,
+          assigneeUser.email,
           updated.status,
           updated.id,
           true
@@ -590,8 +588,8 @@ export default class RequestsService extends moleculer.Service {
         ),
       };
     } else if (
-      request.assignedTo &&
-      Number(request.assignedTo) === Number(user.id)
+      request.assignee &&
+      Number(request.assignee) === Number(user.id)
     ) {
       return {
         edit: false,
@@ -639,13 +637,13 @@ export default class RequestsService extends moleculer.Service {
     ) {
       let recipientEmail = NOTIFY_ADMIN_EMAIL;
 
-      if (request.assignedTo) {
-        const assignee: User = await this.broker.call('users.resolve', {
-          id: request.assignedTo,
+      if (request.assignee) {
+        const assigneeUser: User = await this.broker.call('users.resolve', {
+          id: request.assignee,
           scope: USERS_DEFAULT_SCOPES,
         });
-        if (assignee?.email) {
-          recipientEmail = assignee.email;
+        if (assigneeUser?.email) {
+          recipientEmail = assigneeUser.email;
         }
       }
 

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -51,6 +51,7 @@ export interface Request extends BaseModelInterface {
   generatedFile: string;
   notifyEmail: string;
   tenant: number | Tenant;
+  assignedTo?: number | User;
   data?: {
     extended?: boolean;
   };
@@ -243,6 +244,12 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
 
       generatedFile: 'string',
 
+      assignedTo: {
+        type: 'number',
+        columnType: 'integer',
+        populate: 'users.resolve',
+      },
+
       notifyEmail: {
         type: 'string',
         onCreate: ({ ctx, value }: FieldHookCallback) => {
@@ -281,7 +288,10 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
         if (profile?.id) {
           return { ...query, tenant: profile.id };
         } else if (user.type === UserType.USER) {
-          return { ...query, ...createdByUserQuery };
+          return {
+            ...query,
+            $or: [createdByUserQuery, { assignedTo: user.id }],
+          };
         }
 
         if (query.createdBy === user.id) {
@@ -392,6 +402,64 @@ export default class RequestsService extends moleculer.Service {
     return {
       generating: !!flow?.job?.id,
     };
+  }
+
+  @Action({
+    params: {
+      id: { type: 'number', convert: true },
+      assignedTo: { type: 'number', convert: true, optional: true },
+    },
+    rest: 'POST /:id/assign',
+    types: [EndpointType.ADMIN],
+  })
+  async assign(
+    ctx: Context<
+      { id: number; assignedTo?: number | null },
+      UserAuthMeta
+    >
+  ) {
+    const { id, assignedTo } = ctx.params;
+
+    const request: Request = await ctx.call('requests.resolve', {
+      id,
+      throwIfNotExist: true,
+    });
+
+    const previousAssignee = request.assignedTo
+      ? Number(request.assignedTo)
+      : null;
+    const nextAssignee = assignedTo ?? null;
+
+    if (previousAssignee === nextAssignee) return request;
+
+    const updated: Request = await this.updateEntity(ctx, {
+      id,
+      assignedTo: nextAssignee,
+    });
+
+    if (emailCanBeSent() && nextAssignee) {
+      const assignee: User = await ctx.call('users.resolve', {
+        id: nextAssignee,
+        scope: USERS_DEFAULT_SCOPES,
+      });
+      if (assignee?.email) {
+        notifyOnRequestUpdate(
+          assignee.email,
+          updated.status,
+          updated.id,
+          true
+        );
+      }
+    } else if (emailCanBeSent() && !nextAssignee && previousAssignee) {
+      notifyOnRequestUpdate(
+        NOTIFY_ADMIN_EMAIL,
+        updated.status,
+        updated.id,
+        true
+      );
+    }
+
+    return updated;
   }
 
   @Action({
@@ -521,6 +589,16 @@ export default class RequestsService extends moleculer.Service {
           request.status
         ),
       };
+    } else if (
+      request.assignedTo &&
+      Number(request.assignedTo) === Number(user.id)
+    ) {
+      return {
+        edit: false,
+        validate: [RequestStatus.CREATED, RequestStatus.SUBMITTED].includes(
+          request.status
+        ),
+      };
     }
 
     return invalid;
@@ -559,8 +637,20 @@ export default class RequestsService extends moleculer.Service {
     if (
       [RequestStatus.CREATED, RequestStatus.SUBMITTED].includes(request.status)
     ) {
+      let recipientEmail = NOTIFY_ADMIN_EMAIL;
+
+      if (request.assignedTo) {
+        const assignee: User = await this.broker.call('users.resolve', {
+          id: request.assignedTo,
+          scope: USERS_DEFAULT_SCOPES,
+        });
+        if (assignee?.email) {
+          recipientEmail = assignee.email;
+        }
+      }
+
       return notifyOnRequestUpdate(
-        NOTIFY_ADMIN_EMAIL,
+        recipientEmail,
         request.status,
         request.id,
         true


### PR DESCRIPTION
## Summary
Lets administrators assign UETK requests and forms to a specific UETK user, who then has the same approve/return/reject powers an admin would on that submission. Naming and REST shape mirror **biip-rusys-api** so the existing admin-web scaffolding can talk to it directly.

### Changes
- **Migration** \`20260505140000_addAssigneeOnRequestsAndForms\` — adds nullable \`assigneeId\` (FK-shaped integer) to both \`requests\` and \`forms\`.
- **\`requests.service\` / \`forms.service\`**
  - New \`assignee\` field (column \`assigneeId\`, populates via \`users.resolve\`).
  - New \`setAssignee\` action: \`POST /:id/assignee/:assignee?\` (admin-only); empty assignee param clears the assignment.
  - \`hasPermissionToEdit\` grants \`validate\` permissions to the current assignee on CREATED/SUBMITTED items, mirroring admin powers.
  - \`visibleToUser\` scope: a non-admin user now also sees items where they are the assignee, not only ones they created.
  - \`sendNotificationOnStatusChange\` for CREATED/SUBMITTED routes the email to the assignee when one is set, else the central admin address. Same routing logic in the \`setAssignee\` flow itself: assigning emails the new assignee, clearing emails the admin (so they can reassign).

### Pairs with
**biip-admin-web** PR — wires the previously commented-out UserPicker on form/request detail pages to these new endpoints, and adds the same picker for requests (it only existed scaffolded for forms).

### Out of scope
"Vacation admin" (admin temporarily delegating receive-and-assign rights to another admin) — would need a per-user "active admin" flag or similar; not implemented here.

## Test plan
- [ ] Run migrations on a fresh DB; confirm \`assignee_id\` column exists on \`requests\` and \`forms\`.
- [ ] As admin, \`POST /requests/:id/assignee/:userId\` for a CREATED request — assignee gets the email, request is visible to that user, that user can approve/return/reject.
- [ ] \`POST /requests/:id/assignee\` (no assignee path param) — clears assignee, central admin email gets the routing notice.
- [ ] Same flow on \`/forms/:id/assignee/:userId\`.
- [ ] Non-admin who isn't creator nor assignee still cannot see or validate the submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)