### PR TITLE
Security audit fixes: lock down auth surface and close data leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,59 @@ jobs:
           wait-for-processing: true
           category: ESLint
 
+  validate:
+    name: Build & test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgis/postgis:14-master
+        ports: ['5436:5432']
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: uetk_test
+          TZ: 'Etc/GMT'
+          PGTZ: 'Etc/GMT'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+
+      redis:
+        image: redis:7
+        ports: ['6671:6379']
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: package.json
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test:ci
+        env:
+          DB_CONNECTION: postgresql://postgres:postgres@localhost:5436/uetk_test
+          GIS_DB_CONNECTION: postgresql://postgres:postgres@localhost:5436/uetk_test
+          REDIS_CONNECTION: redis://localhost:6671
+
   validate-docker-build:
     name: Validate if docker image builds
     uses: AplinkosMinisterija/reusable-workflows/.github/workflows/docker-build-push.yml@main

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,13 @@ module.exports = {
   },
   testMatch: ['**/test/**/*.spec.(ts|js)'],
   testTimeout: 120000,
+  // postmark v4 ships ESM-only and our utils/mails.ts pulls it transitively.
+  // Jest 27 + ts-jest run in CJS mode, so the ESM `import axios from ...` in
+  // postmark's source blows up the suite. Mail flows aren't part of any
+  // security test path, so we swap the module for a no-op stub.
+  moduleNameMapper: {
+    '^postmark$': '<rootDir>/test/helpers/stub-postmark.js',
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.json',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  setupFiles: ['./test/helpers/setup.js'],
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  testMatch: ['**/test/**/*.spec.(ts|js)'],
+  testTimeout: 120000,
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cli": "moleculer connect NATS",
     "ci": "jest --watch",
     "test": "jest --coverage --passWithNoTests",
+    "test:ci": "jest --runInBand --forceExit",
     "lint": "eslint --ext .js,.ts .",
     "lint:sarif": "set SARIF_ESLINT_EMBED=true && yarn run lint --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
     "dc:up": "docker-compose -p biip-uetk-api up --build -d",

--- a/package.json
+++ b/package.json
@@ -73,25 +73,5 @@
   },
   "engines": {
     "node": ">=18.0.0 <19.0.0"
-  },
-  "jest": {
-    "coverageDirectory": "<rootDir>/coverage",
-    "testEnvironment": "node",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
-    "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
-    },
-    "testMatch": [
-      "**/*.spec.(ts|js)"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.json"
-      }
-    }
   }
 }

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -28,15 +28,14 @@ export const AuthType = {
     port: process.env.PORT || 3000,
     path: '/uetk',
 
-    // Global CORS settings for all routes
+    // Global CORS settings for all routes. We keep origin: '*' on purpose —
+    // the API is Bearer-token based (no cookies), so classic CSRF doesn't apply
+    // and the wildcard keeps public endpoints reachable from third parties.
     cors: {
-      // Configures the Access-Control-Allow-Origin CORS header.
       origin: '*',
-      // Configures the Access-Control-Allow-Methods CORS header.
-      methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'DELETE'],
-      // Configures the Access-Control-Allow-Headers CORS header.
+      methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE'],
       allowedHeaders: '*',
-      // Configures the Access-Control-Max-Age CORS header.
+      credentials: false,
       maxAge: 3600,
     },
 
@@ -162,8 +161,10 @@ export const AuthType = {
           },
         },
 
-        // Mapping policy setting. More info: https://moleculer.services/docs/0.14/moleculer-web.html#Mapping-policy
-        mappingPolicy: 'all', // Available values: "all", "restrict"
+        // Restrict to explicit aliases + autoAliases-generated REST routes. With
+        // 'all', any @Action could be reached via /<service>/<action>, exposing
+        // internal actions without types: [...] gates.
+        mappingPolicy: 'restrict',
 
         // Enable/disable logging
         logging: true,
@@ -197,9 +198,8 @@ export default class ApiService extends moleculer.Service {
     rest: {
       method: 'POST',
       path: '/cache/clean',
-      basePath: '/public',
     },
-    auth: AuthType.PUBLIC,
+    types: [EndpointType.ADMIN],
   })
   cleanCache() {
     this.broker.cacher.clean();

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -13,6 +13,7 @@ import {
   COMMON_FIELDS,
   COMMON_SCOPES,
   ContextMeta,
+  EndpointType,
   EntityChangedParams,
   FieldHookCallback,
   NOTIFY_ADMIN_EMAIL,
@@ -148,6 +149,19 @@ const populatePermissions = (field: string) => {
         type: 'array',
         columnType: 'json',
         items: { type: 'object' },
+        // Sign each file URL on read (same rationale as requests.generatedFile)
+        async get({ ctx, value }: FieldHookCallback) {
+          if (!Array.isArray(value)) return value;
+          return Promise.all(
+            value.map(async (file: any) => {
+              if (!file?.url) return file;
+              const signed = await ctx.call('minio.signStoredUrl', {
+                url: file.url,
+              });
+              return { ...file, url: signed };
+            })
+          );
+        },
       },
 
       providerType: {
@@ -202,7 +216,8 @@ const populatePermissions = (field: string) => {
       ...COMMON_SCOPES,
       visibleToUser(query: any, ctx: Context<null, UserAuthMeta>, params: any) {
         const { user, profile } = ctx?.meta;
-        if (!user?.id) return query;
+        // Deny-by-default for unauthenticated callers (defense-in-depth).
+        if (!user?.id) return { ...query, id: -1 };
 
         const createdByUserQuery = {
           createdBy: user?.id,
@@ -234,10 +249,45 @@ const populatePermissions = (field: string) => {
   },
 
   actions: {
+    // Authorization: any authenticated user can hit the CRUD routes; the
+    // visibleToUser scope handles per-tenant / per-user data filtering.
+    create: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
+    list: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
+    get: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
     update: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
       additionalParams: {
         comment: { type: 'string', optional: true },
       },
+    },
+    remove: {
+      types: [EndpointType.ADMIN],
     },
   },
 })
@@ -250,6 +300,12 @@ export default class FormsService extends moleculer.Service {
         convert: true,
       },
     },
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async getHistory(
     ctx: Context<{
@@ -280,6 +336,12 @@ export default class FormsService extends moleculer.Service {
         },
       },
     },
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async upload(ctx: Context<{}, UserAuthMeta>) {
     const folder = this.getFolderName(ctx.meta?.user, ctx.meta?.profile);

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -242,7 +242,8 @@ const populatePermissions = (field: string) => {
       visibleToUser(query: any, ctx: Context<null, UserAuthMeta>, params: any) {
         const { user, profile } = ctx?.meta;
         // Deny-by-default for unauthenticated callers (defense-in-depth).
-        if (!user?.id) return { ...query, id: -1 };
+        // See requests.visibleToUser for why we use createdBy not id.
+        if (!user?.id) return { ...query, createdBy: -1 };
 
         const createdByUserQuery = {
           createdBy: user?.id,

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -149,6 +149,31 @@ const populatePermissions = (field: string) => {
         type: 'array',
         columnType: 'json',
         items: { type: 'object' },
+        // Reject client-supplied file URLs that point outside the caller's own
+        // upload folder. Without this an attacker could submit a form with
+        // files[].url referencing another tenant's object and then read it
+        // back to obtain a fresh presigned URL via the get hook below.
+        // (minio.signStoredUrl also enforces ownership on read as defense-in-depth.)
+        set: ({ ctx, value }: FieldHookCallback) => {
+          if (!Array.isArray(value)) return value;
+          const meta = ctx?.meta as UserAuthMeta | undefined;
+          if (!meta?.user?.id || meta.user.type === UserType.ADMIN) return value;
+          const ownedPrefix = `uploads/forms/${
+            meta.profile?.id || 'private'
+          }/${meta.user.id}/`;
+          return value.filter((item: any) => {
+            if (!item?.url || typeof item.url !== 'string') return true;
+            const idx = item.url.indexOf('/minio/');
+            if (idx === -1) return true; // not one of our managed URLs
+            const rest = item.url.slice(idx + '/minio/'.length);
+            const [, ...objectParts] = rest.split('/');
+            const objectName = objectParts.join('/');
+            if (objectName.includes('..') || objectName.includes('\\')) {
+              return false;
+            }
+            return objectName.startsWith(ownedPrefix);
+          });
+        },
         // Sign each file URL on read (same rationale as requests.generatedFile)
         async get({ ctx, value }: FieldHookCallback) {
           if (!Array.isArray(value)) return value;

--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -4,18 +4,51 @@
 import MinioMixin from 'moleculer-minio';
 import Moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
-import { UserAuthMeta, AuthType } from './api.service';
+import { UserAuthMeta } from './api.service';
 import {
+  EndpointType,
   getExtention,
   getMimetype,
   getPublicFileName,
   IMAGE_TYPES,
   MultipartMeta,
+  throwBadRequestError,
   throwNotFoundError,
   throwUnableToUploadError,
   throwUnsupportedMimetypeError,
 } from '../types';
 import moment from 'moment';
+
+// Folder prefixes a caller is allowed to write to / delete from. Computed
+// against the caller's identity (tenant profile or freelance user). Without
+// this check uploadFile's `folder` parameter let an authenticated user write
+// into someone else's private namespace.
+function callerOwnedFolders(meta: UserAuthMeta): string[] {
+  const userId = meta?.user?.id;
+  const tenantId = meta?.profile?.id;
+  const folders: string[] = [];
+  // Cover both upload prefixes used in the codebase (forms, requests).
+  for (const kind of ['forms', 'requests']) {
+    folders.push(`uploads/${kind}/private/${userId ?? 'user'}`);
+    if (tenantId) folders.push(`uploads/${kind}/${tenantId}/${userId ?? 'user'}`);
+  }
+  return folders;
+}
+
+function isFolderOwnedByCaller(folder: string, meta: UserAuthMeta): boolean {
+  if (!folder || typeof folder !== 'string') return false;
+  const normalized = folder.replace(/^\/+|\/+$/g, '');
+  // Reject any path-traversal attempt before substring matching.
+  if (normalized.includes('..') || normalized.includes('\\')) return false;
+  // System / background worker context (no user identity) is trusted — the
+  // calling action (e.g. jobs.requests.generateAndSavePdf) computed the folder
+  // from validated request data, not from request params.
+  if (!meta?.user?.id) return true;
+  if (meta.user.type === 'ADMIN') return true;
+  return callerOwnedFolders(meta).some(
+    (owned) => normalized === owned || normalized.startsWith(`${owned}/`)
+  );
+}
 
 export const BUCKET_NAME = () => process.env.MINIO_BUCKET || 'uetk';
 
@@ -44,6 +77,7 @@ export default class MinioService extends Moleculer.Service {
         default: false,
       },
     },
+    visibility: 'protected',
   })
   getUrl(
     ctx: Context<{
@@ -55,6 +89,37 @@ export default class MinioService extends Moleculer.Service {
     const { bucketName, objectName, isPrivate } = ctx.params;
 
     return this.getObjectUrl(objectName, isPrivate, bucketName);
+  }
+
+  /**
+   * Convert a stored "private" object URL into a freshly-signed presigned URL.
+   * Returns the input unchanged when the stored value is not one of our private
+   * proxy URLs (e.g. already absolute MinIO public URL, external string).
+   * Lets FE keep using `<a href={url}>` without sending an Authorization header.
+   */
+  @Action({
+    params: { url: 'string' },
+    visibility: 'protected',
+  })
+  async signStoredUrl(ctx: Context<{ url: string }>) {
+    const { url } = ctx.params;
+    if (!url || typeof url !== 'string') return url;
+
+    const marker = '/minio/';
+    const idx = url.indexOf(marker);
+    if (idx === -1) return url;
+
+    const rest = url.slice(idx + marker.length);
+    const [bucketName, ...objectParts] = rest.split('/');
+    const objectName = objectParts.join('/');
+    if (!bucketName || !objectName) return url;
+
+    try {
+      return await this.getPresignedUrl(ctx, objectName, bucketName);
+    } catch (err) {
+      this.logger.warn('signStoredUrl failed, returning raw URL', err);
+      return url;
+    }
   }
 
   @Action({
@@ -80,6 +145,9 @@ export default class MinioService extends Moleculer.Service {
       },
     },
     timeout: 0,
+    // Not directly callable via API — go through forms.upload / requests flows
+    // which set folder/isPrivate from authenticated context.
+    visibility: 'protected',
   })
   async uploadFile(
     ctx: Context<
@@ -104,6 +172,10 @@ export default class MinioService extends Moleculer.Service {
       presign,
     } = ctx.params;
     const name = defaultName || getPublicFileName(50);
+
+    if (!isFolderOwnedByCaller(folder, ctx.meta)) {
+      throwBadRequestError('Folder not allowed for this caller');
+    }
 
     if (!types.includes(mimetype)) {
       throwUnsupportedMimetypeError();
@@ -169,13 +241,18 @@ export default class MinioService extends Moleculer.Service {
         },
       },
     },
-    auth: AuthType.PUBLIC,
     rest: 'GET /:bucket/:name+',
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async getFile(
     ctx: Context<
       { bucket: string; name: string[] },
-      {
+      UserAuthMeta & {
         $responseHeaders: any;
         $statusCode: number;
         $statusMessage: string;
@@ -184,11 +261,20 @@ export default class MinioService extends Moleculer.Service {
     >
   ) {
     const { bucket, name } = ctx.params;
+    const objectName = name.join('/');
+
+    // Admins read anything; everyone else must own the folder.
+    if (
+      ctx.meta?.user?.type !== 'ADMIN' &&
+      !isFolderOwnedByCaller(objectName, ctx.meta)
+    ) {
+      return throwNotFoundError('File not found.');
+    }
 
     try {
       const reader: NodeJS.ReadableStream = await ctx.call('minio.getObject', {
         bucketName: bucket,
-        objectName: name.join('/'),
+        objectName,
       });
 
       const filename = name[name.length - 1];
@@ -211,6 +297,7 @@ export default class MinioService extends Moleculer.Service {
         default: BUCKET_NAME(),
       },
     },
+    visibility: 'protected',
   })
   async fileStat(ctx: Context<{ bucketName: string; objectName: string }>) {
     const { bucketName, objectName } = ctx.params;
@@ -249,16 +336,30 @@ export default class MinioService extends Moleculer.Service {
     params: {
       path: 'string',
     },
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
-  async removeFile(ctx: Context<{ path: string }>) {
+  async removeFile(ctx: Context<{ path: string }, UserAuthMeta>) {
     const { path } = ctx.params;
 
     const [bucket, ...paths] = path.split('/');
+    const objectName = paths.join('/');
+
+    if (
+      ctx.meta?.user?.type !== 'ADMIN' &&
+      !isFolderOwnedByCaller(objectName, ctx.meta)
+    ) {
+      return { success: false };
+    }
 
     try {
       const result = await ctx.call('minio.removeObject', {
         bucketName: bucket,
-        objectName: paths.join('/'),
+        objectName,
       });
       return { success: !result };
     } catch (err) {

--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -94,14 +94,18 @@ export default class MinioService extends Moleculer.Service {
   /**
    * Convert a stored "private" object URL into a freshly-signed presigned URL.
    * Returns the input unchanged when the stored value is not one of our private
-   * proxy URLs (e.g. already absolute MinIO public URL, external string).
-   * Lets FE keep using `<a href={url}>` without sending an Authorization header.
+   * proxy URLs (e.g. already absolute MinIO public URL, external string), OR
+   * when the caller does not own the underlying object — without this last
+   * check the action becomes a presigned-URL oracle for arbitrary MinIO objects
+   * (attacker writes /minio/uetk/uploads/requests/private/<victim>/file.pdf
+   * into forms.files[].url or requests.generatedFile, reads it back, and gets
+   * a signed URL they can hit directly against MinIO).
    */
   @Action({
     params: { url: 'string' },
     visibility: 'protected',
   })
-  async signStoredUrl(ctx: Context<{ url: string }>) {
+  async signStoredUrl(ctx: Context<{ url: string }, UserAuthMeta>) {
     const { url } = ctx.params;
     if (!url || typeof url !== 'string') return url;
 
@@ -113,6 +117,14 @@ export default class MinioService extends Moleculer.Service {
     const [bucketName, ...objectParts] = rest.split('/');
     const objectName = objectParts.join('/');
     if (!bucketName || !objectName) return url;
+
+    // Ownership check. isFolderOwnedByCaller already returns true for system
+    // (no user meta) and ADMIN callers, so background workers and admins still
+    // get signed URLs. Regular users only get signing for objects in their own
+    // tenant/user folder.
+    if (!isFolderOwnedByCaller(objectName, ctx.meta)) {
+      return url;
+    }
 
     try {
       return await this.getPresignedUrl(ctx, objectName, bucketName);

--- a/services/objects.service.ts
+++ b/services/objects.service.ts
@@ -6,7 +6,6 @@ import { Action, Service } from 'moleculer-decorators';
 import { FeatureCollection } from 'geojsonjs';
 import { gisConfig } from '../knexfile';
 import DbConnection from '../mixins/database.mixin';
-import { throwBadRequestError } from '../types';
 
 import { snakeCase } from 'lodash';
 import PostgisMixin from 'moleculer-postgis';
@@ -222,6 +221,10 @@ export default class ObjectsService extends moleculer.Service {
         type: 'array',
         optional: true,
         items: 'string',
+        // Allowlist of columns the public search can hit. Used to be unconstrained
+        // which let a caller smuggle anything into the SQL ILIKE clause via the
+        // searchFields[] param.
+        enum: ['name', 'cadastralId', 'municipality'],
         default: ['name', 'cadastralId'],
       },
     },
@@ -238,25 +241,25 @@ export default class ObjectsService extends moleculer.Service {
     delete ctx.params.search;
     delete ctx.params.searchFields;
 
-    const searchValueFixed = search?.replace(
-      /([-[\]{}()*+?.,%\\^$|#\s;])/gi,
-      '\\$&'
-    );
+    let textRaw: { condition: string; bindings: any[] } | undefined;
 
-    if (/[;%]/gi.test(search)) {
-      throwBadRequestError('Invalid search', { search });
+    if (search) {
+      // Build a parameterized ILIKE per allowed column using knex bindings —
+      // the column identifiers are resolved against settings.fields so callers
+      // cannot inject arbitrary SQL through searchFields[].
+      const columns = searchFields
+        .map((field) => this.settings.fields?.[field]?.columnName || field)
+        .map((field) => snakeCase(field));
+
+      const condition = columns.map((c) => `"${c}" ILIKE ?`).join(' OR ');
+      const pattern = `%${search}%`;
+      const bindings = columns.map(() => pattern);
+      textRaw = { condition, bindings };
     }
-
-    const textQuery = searchFields
-      .map((field) => {
-        field = this.settings.fields?.[field]?.columnName || field;
-        return `"${snakeCase(field)}" ilike '%${searchValueFixed}%'`;
-      })
-      .join(' OR ');
 
     return ctx.call('objects.list', {
       ...ctx.params,
-      query: { ...(query || {}), ...(search ? { $raw: textQuery } : {}) },
+      query: { ...(query || {}), ...(textRaw ? { $raw: textRaw } : {}) },
       sort: 'name',
     });
   }

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -6,7 +6,7 @@ import { Action, Event, Method, Service } from 'moleculer-decorators';
 import { FeatureCollection } from 'geojsonjs';
 import PostgisMixin, { GeometryType } from 'moleculer-postgis';
 import DbConnection from '../mixins/database.mixin';
-import { AuthType, UserAuthMeta } from './api.service';
+import { UserAuthMeta } from './api.service';
 
 import moment from 'moment';
 import { Readable } from 'stream';
@@ -249,7 +249,17 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
         populate: populatePermissions('validate'),
       },
 
-      generatedFile: 'string',
+      generatedFile: {
+        type: 'string',
+        // Sign on read so FE can keep using <a href={url}> downloads without
+        // sending an Authorization header. The stored value is a relative
+        // private-proxy URL; minio.signStoredUrl issues a fresh presigned URL
+        // that hits MinIO directly with the embedded signature.
+        async get({ ctx, value }: FieldHookCallback) {
+          if (!value || typeof value !== 'string') return value;
+          return ctx.call('minio.signStoredUrl', { url: value });
+        },
+      },
 
       notifyEmail: {
         type: 'string',
@@ -284,7 +294,12 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
       ...COMMON_SCOPES,
       visibleToUser(query: any, ctx: Context<null, UserAuthMeta>) {
         const { user, profile } = ctx?.meta;
-        if (!user?.id) return query;
+        // Deny-by-default for unauthenticated callers: scope used to return the
+        // raw query, which made any internal ctx.call('requests.resolve') from
+        // a PUBLIC action expose every request. The route-level auth still
+        // gates HTTP, but defense-in-depth matters when actions invoke each
+        // other via ctx.call.
+        if (!user?.id) return { ...query, id: -1 };
 
         const createdByUserQuery = {
           createdBy: user?.id,
@@ -360,10 +375,47 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
   },
 
   actions: {
+    // Authorization: any authenticated user can hit the CRUD routes, but the
+    // visibleToUser scope ensures USERs only see their own and TENANT_USERs
+    // only see their tenant's. Admins see everything. Public callers blocked
+    // at the auth layer.
+    create: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
+    list: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
+    get: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
+    },
     update: {
+      types: [
+        EndpointType.ADMIN,
+        EndpointType.USER,
+        EndpointType.TENANT_USER,
+        EndpointType.TENANT_ADMIN,
+      ],
       additionalParams: {
         comment: { type: 'string', optional: true },
       },
+    },
+    remove: {
+      types: [EndpointType.ADMIN],
     },
   },
 })
@@ -376,6 +428,12 @@ export default class RequestsService extends moleculer.Service {
         convert: true,
       },
     },
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async getHistory(
     ctx: Context<{
@@ -419,6 +477,12 @@ export default class RequestsService extends moleculer.Service {
     },
     rest: 'POST /:id/generate',
     timeout: 0,
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async generatePdf(ctx: Context<{ id: number }>) {
     const flow: any = await ctx.call('jobs.requests.initiatePdfGenerate', {
@@ -532,8 +596,13 @@ export default class RequestsService extends moleculer.Service {
         convert: true,
       },
     },
-    auth: AuthType.PUBLIC,
     rest: 'GET /:id/geom',
+    types: [
+      EndpointType.ADMIN,
+      EndpointType.USER,
+      EndpointType.TENANT_USER,
+      EndpointType.TENANT_ADMIN,
+    ],
   })
   async getRequestGeom(ctx: Context<{ id: number }>) {
     const request: Request = await ctx.call('requests.resolve', {

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -482,14 +482,13 @@ export default class RequestsService extends moleculer.Service {
   saveGeneratedPdf(ctx: Context<{ id: number; url: string }>) {
     const { id, url: generatedFile } = ctx.params;
 
-    return this.updateEntity(
-      ctx,
-      {
-        id,
-        generatedFile,
-        scope: 'notDeleted',
-      }
-    );
+    return this.updateEntity(ctx, {
+      id,
+      generatedFile,
+      // Drop visibleToUser from defaultScopes — keep notDeleted in place.
+      // @moleculer/database reads `-<scopeName>` as "remove from defaults".
+      scope: ['-visibleToUser'],
+    });
   }
 
   @Action({

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -474,21 +474,43 @@ export default class RequestsService extends moleculer.Service {
       url: 'string',
     },
     // System-only: called by jobs.requests.generateAndSavePdf in a background
-    // worker context with no user meta. visibleToUser scope deny-by-default
-    // would now block that path, so we pass an explicit scope list that keeps
-    // soft-delete protection but skips per-user visibility.
+    // worker context with no user meta. visibility: 'protected' keeps it off
+    // the API gateway entirely so the scope override below cannot be reached
+    // by an external caller — only by another in-broker service. Combined
+    // with the state assertion below, a misbehaving sibling service still
+    // can't overwrite a finalized PDF URL.
     visibility: 'protected',
   })
-  saveGeneratedPdf(ctx: Context<{ id: number; url: string }>) {
+  async saveGeneratedPdf(ctx: Context<{ id: number; url: string }>) {
     const { id, url: generatedFile } = ctx.params;
 
-    return this.updateEntity(ctx, {
-      id,
-      generatedFile,
-      // Drop visibleToUser from defaultScopes — keep notDeleted in place.
-      // @moleculer/database reads `-<scopeName>` as "remove from defaults".
-      scope: ['-visibleToUser'],
-    });
+    // Independent ownership / state check before bypassing visibleToUser.
+    // PDF generation is only legitimate for requests the system has decided
+    // to process (status APPROVED via auto-approve or admin approval). Block
+    // writes to any other state so a stray service-to-service call can't be
+    // used as an overwrite oracle.
+    const entity: Request = await this.resolveEntities(
+      ctx,
+      { id, scope: ['-visibleToUser'] },
+      { throwIfNotExist: false }
+    );
+    if (!entity) {
+      return throwValidationError('Request not found');
+    }
+    if (entity.status !== RequestStatus.APPROVED) {
+      return throwValidationError(
+        `Cannot persist generated file for status ${entity.status}`
+      );
+    }
+
+    // updateEntity reads `scope` from its third (opts) argument, not from
+    // params. Pass `-visibleToUser` there so the internal pre-resolve also
+    // skips the deny-by-default filter.
+    return this.updateEntity(
+      ctx,
+      { id, generatedFile },
+      { scope: ['-visibleToUser'] }
+    );
   }
 
   @Action({

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -473,14 +473,23 @@ export default class RequestsService extends moleculer.Service {
       id: 'number',
       url: 'string',
     },
+    // System-only: called by jobs.requests.generateAndSavePdf in a background
+    // worker context with no user meta. visibleToUser scope deny-by-default
+    // would now block that path, so we pass an explicit scope list that keeps
+    // soft-delete protection but skips per-user visibility.
+    visibility: 'protected',
   })
   saveGeneratedPdf(ctx: Context<{ id: number; url: string }>) {
     const { id, url: generatedFile } = ctx.params;
 
-    return this.updateEntity(ctx, {
-      id,
-      generatedFile,
-    });
+    return this.updateEntity(
+      ctx,
+      {
+        id,
+        generatedFile,
+        scope: 'notDeleted',
+      }
+    );
   }
 
   @Action({

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -310,7 +310,11 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
         // a PUBLIC action expose every request. The route-level auth still
         // gates HTTP, but defense-in-depth matters when actions invoke each
         // other via ctx.call.
-        if (!user?.id) return { ...query, id: -1 };
+        //
+        // We use createdBy: -1 rather than id: -1 because resolve()'s explicit
+        // params.id wins over a scope-supplied id filter — a sentinel on a
+        // non-PK field always applies.
+        if (!user?.id) return { ...query, createdBy: -1 };
 
         const createdByUserQuery = {
           createdBy: user?.id,

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -251,6 +251,17 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
 
       generatedFile: {
         type: 'string',
+        // Block client writes — generatedFile is system-managed (populated by
+        // jobs.requests.generateAndSavePdf). Without this guard a regular user
+        // could PATCH /requests/:id with generatedFile pointing at another
+        // tenant's PDF; combined with the get hook below that would have
+        // returned a presigned URL even for objects the user doesn't own.
+        // (signStoredUrl now also blocks non-owners as defense-in-depth.)
+        set: ({ ctx, value, entity }: FieldHookCallback) => {
+          const meta = ctx?.meta as UserAuthMeta | undefined;
+          if (!meta?.user?.id || meta.user.type === UserType.ADMIN) return value;
+          return entity?.generatedFile;
+        },
         // Sign on read so FE can keep using <a href={url}> downloads without
         // sending an Authorization header. The stored value is a relative
         // private-proxy URL; minio.signStoredUrl issues a fresh presigned URL

--- a/services/search.service.ts
+++ b/services/search.service.ts
@@ -65,16 +65,14 @@ export default class SearchService extends moleculer.Service {
     let rows: any[] = await this.getGisData();
 
     if (!!search) {
+      const needle = String(search).toLowerCase();
       rows = rows.filter((f: any) => {
         const props = f.properties;
 
         return searchFields.some((sField) => {
-          if (!props[sField]) return false;
-
-          if (typeof props[sField] === 'string') {
-            const regex = new RegExp(`${search}`, 'gi');
-            return regex.test(props[sField]);
-          }
+          const value = props[sField];
+          if (!value || typeof value !== 'string') return false;
+          return value.toLowerCase().includes(needle);
         });
       });
     }

--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -89,6 +89,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async getRole(ctx: Context<{ tenant: number; user: number }>) {
     const tenantUser: TenantUser = await ctx.call('tenantUsers.findOne', {
@@ -190,6 +191,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async findByUser(ctx: Context<{ id: number }>) {
     const tenantUsers: TenantUser[] = await ctx.call('tenantUsers.find', {
@@ -212,6 +214,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async findIdsByUser(ctx: Context<{ id: number }>) {
     const tenantUsers: TenantUser[] = await ctx.call('tenantUsers.find', {
@@ -234,6 +237,7 @@ export default class TenantUsersService extends moleculer.Service {
         optional: true,
       },
     },
+    visibility: 'protected',
   })
   async findIdsByTenant(ctx: Context<{ id: number; role?: string }>) {
     const { id, role } = ctx.params;
@@ -263,6 +267,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async userExistsInTenant(ctx: Context<{ userId: number; tenantId: number }>) {
     const tenantUser: TenantUser = await ctx.call('tenantUsers.findOne', {
@@ -295,6 +300,7 @@ export default class TenantUsersService extends moleculer.Service {
         optional: true,
       },
     },
+    visibility: 'protected',
   })
   async createRelationshipsIfNeeded(
     ctx: Context<{
@@ -408,6 +414,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async removeUsers(ctx: Context<{ tenantId: number }, UserAuthMeta>) {
     const { tenantId } = ctx.params;
@@ -461,6 +468,7 @@ export default class TenantUsersService extends moleculer.Service {
         convert: true,
       },
     },
+    visibility: 'protected',
   })
   async removeTenants(ctx: Context<{ userId: number }, UserAuthMeta>) {
     const { userId } = ctx.params;
@@ -648,6 +656,7 @@ export default class TenantUsersService extends moleculer.Service {
     cache: {
       keys: ['id', 'profile'],
     },
+    visibility: 'protected',
   })
   async getProfile(ctx: Context<{ id: number; profile: number }>) {
     const tenantUser: TenantUser = await ctx.call('tenantUsers.findOne', {

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -3,7 +3,67 @@
 import moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
 import { toReadableStream } from '../utils';
+import { throwBadRequestError } from '../types';
 import { AuthType } from './api.service';
+
+// Hosts the tools service is allowed to fetch on behalf of a caller. Anything
+// outside this set is rejected before we hand the URL to the screenshot/PDF
+// renderer — without it `tools.download` (PUBLIC) and `tools.makeScreenshot`
+// were a general-purpose SSRF reflector pointed at internal IPs.
+function allowedToolHosts(): Set<string> {
+  const hosts = new Set<string>();
+  const candidates = [
+    process.env.MAPS_HOST,
+    process.env.SERVER_HOST,
+    process.env.APP_HOST,
+    process.env.QGIS_SERVER_HOST,
+    process.env.TOOLS_ALLOWED_HOSTS, // comma-separated extra allowlist
+  ].filter(Boolean) as string[];
+
+  for (const raw of candidates) {
+    for (const entry of raw.split(',')) {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      try {
+        const u = new URL(trimmed);
+        hosts.add(u.host.toLowerCase());
+      } catch {
+        hosts.add(trimmed.toLowerCase());
+      }
+    }
+  }
+
+  return hosts;
+}
+
+function assertSafeToolUrl(url: string) {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throwBadRequestError('Invalid URL');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throwBadRequestError('Only http(s) URLs are allowed');
+  }
+
+  const hosts = allowedToolHosts();
+  if (hosts.size === 0) {
+    // No allowlist configured — fail closed in production, allow in dev so
+    // local testing isn't blocked.
+    if (process.env.NODE_ENV === 'production') {
+      throwBadRequestError('Tools allowlist not configured');
+    }
+    return parsed;
+  }
+
+  if (!hosts.has(parsed.host.toLowerCase())) {
+    throwBadRequestError(`Host not allowed: ${parsed.host}`);
+  }
+
+  return parsed;
+}
 
 @Service({
   name: 'tools',
@@ -37,6 +97,7 @@ export default class ToolsService extends moleculer.Service {
     }>
   ) {
     const { url, stream, encoding, waitFor } = ctx.params;
+    assertSafeToolUrl(url);
     const searchParams = new URLSearchParams({
       quality: '75',
       url: url,
@@ -78,6 +139,7 @@ export default class ToolsService extends moleculer.Service {
     ctx: Context<{ url: string; header?: string; footer?: string }>
   ) {
     const { url, footer, header } = ctx.params;
+    assertSafeToolUrl(url);
 
     const pdfEndpoint = `${this.toolsHost()}/pdf`;
 
@@ -126,6 +188,7 @@ export default class ToolsService extends moleculer.Service {
     >
   ) {
     const { url, name } = ctx.params;
+    assertSafeToolUrl(url);
 
     const downloadEndpoint = `${this.toolsHost()}/download`;
 

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -36,7 +36,7 @@ function allowedToolHosts(): Set<string> {
   return hosts;
 }
 
-function assertSafeToolUrl(url: string) {
+export function assertSafeToolUrl(url: string) {
   let parsed: URL;
   try {
     parsed = new URL(url);

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -303,6 +303,7 @@ export default class UsersService extends moleculer.Service {
     cache: {
       keys: ['authUser.id'],
     },
+    visibility: 'protected',
   })
   async resolveByAuthUser(ctx: Context<{ authUser: any }>) {
     const user: User = await ctx.call('users.findOrCreate', {
@@ -336,6 +337,7 @@ export default class UsersService extends moleculer.Service {
         optional: true,
       },
     },
+    visibility: 'protected',
   })
   async findOrCreate(
     ctx: Context<{
@@ -453,6 +455,7 @@ export default class UsersService extends moleculer.Service {
         optional: true,
       },
     },
+    types: [EndpointType.ADMIN, EndpointType.TENANT_ADMIN],
   })
   async updateUser(
     ctx: Context<

--- a/test/helpers/broker.ts
+++ b/test/helpers/broker.ts
@@ -212,12 +212,24 @@ export async function runMigrations() {
     for (const t of tablesInReverseOrder) {
       await k.schema.dropTableIfExists(t);
     }
-    // Drop enum types created by 20230503114642_setup.js so re-running
-    // migrations within a single Jest process doesn't error out.
-    const enums = ['user_type', 'request_status', 'form_status', 'form_type'];
-    for (const e of enums) {
-      await k.raw(`DROP TYPE IF EXISTS ?? CASCADE`, [e]);
-    }
+    // Drop every user-defined enum in the public schema so re-running
+    // migrations within a single Jest process doesn't trip on
+    // `type "..." already exists`. Hard-coding the list is fragile — new
+    // migrations add new enums (tenant_user_role was the one we missed).
+    await k.raw(`
+      DO $$
+      DECLARE r RECORD;
+      BEGIN
+        FOR r IN (
+          SELECT t.typname
+          FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+          WHERE n.nspname = 'public' AND t.typtype = 'e'
+        ) LOOP
+          EXECUTE 'DROP TYPE IF EXISTS public.' || quote_ident(r.typname) || ' CASCADE';
+        END LOOP;
+      END $$;
+    `);
     await k.migrate.latest();
   } finally {
     await k.destroy();

--- a/test/helpers/broker.ts
+++ b/test/helpers/broker.ts
@@ -189,12 +189,15 @@ export function buildBroker() {
 /**
  * Wipe + migrate the test database. Idempotent. Run once before broker.start
  * in beforeAll.
+ *
+ * Each spec file gets a fresh broker + fresh migrations; we drop all known
+ * tables AND the enum types created by migrations (user_type etc.), otherwise
+ * the second migrate.latest() in the same Jest run hits
+ * `type "user_type" already exists`.
  */
 export async function runMigrations() {
   const k = knex(knexConfig);
   try {
-    // Drop+recreate test tables. We only touch tables we know about so a
-    // shared dev DB doesn't get nuked.
     const tablesInReverseOrder = [
       'forms_histories',
       'requests_histories',
@@ -208,6 +211,12 @@ export async function runMigrations() {
     ];
     for (const t of tablesInReverseOrder) {
       await k.schema.dropTableIfExists(t);
+    }
+    // Drop enum types created by 20230503114642_setup.js so re-running
+    // migrations within a single Jest process doesn't error out.
+    const enums = ['user_type', 'request_status', 'form_status', 'form_type'];
+    for (const e of enums) {
+      await k.raw(`DROP TYPE IF EXISTS ?? CASCADE`, [e]);
     }
     await k.migrate.latest();
   } finally {

--- a/test/helpers/broker.ts
+++ b/test/helpers/broker.ts
@@ -1,0 +1,295 @@
+'use strict';
+
+import { ServiceBroker, ServiceSchema } from 'moleculer';
+import { knex } from 'knex';
+import { config as knexConfig } from '../../knexfile';
+
+// Real services we want to exercise — anything carrying scope filters,
+// field hooks, or the security-audit fixes belongs here.
+const RequestsService = require('../../services/requests.service').default;
+const RequestsHistoriesService =
+  require('../../services/requests.histories.service').default;
+const FormsService = require('../../services/forms.service').default;
+const FormsHistoriesService =
+  require('../../services/forms.histories.service').default;
+const UsersService = require('../../services/users.service').default;
+const TenantsService = require('../../services/tenants.service').default;
+const TenantUsersService =
+  require('../../services/tenantUsers.service').default;
+
+/**
+ * Stub `minio` service. Real signStoredUrl + folder ownership logic lives in
+ * services/minio.service.ts, but pulling that file into tests drags in the
+ * moleculer-minio mixin which wants a live S3 endpoint. We re-implement the
+ * tiny piece of logic the field hooks depend on so set/get hooks can call
+ * minio.signStoredUrl without hitting real MinIO.
+ */
+function callerOwnedFolders(meta: any): string[] {
+  const userId = meta?.user?.id;
+  const tenantId = meta?.profile?.id;
+  const folders: string[] = [];
+  for (const kind of ['forms', 'requests']) {
+    folders.push(`uploads/${kind}/private/${userId ?? 'user'}`);
+    if (tenantId) folders.push(`uploads/${kind}/${tenantId}/${userId ?? 'user'}`);
+  }
+  return folders;
+}
+
+function isFolderOwnedByCaller(folder: string, meta: any): boolean {
+  if (!folder || typeof folder !== 'string') return false;
+  const normalized = folder.replace(/^\/+|\/+$/g, '');
+  if (normalized.includes('..') || normalized.includes('\\')) return false;
+  if (!meta?.user?.id) return true;
+  if (meta.user.type === 'ADMIN') return true;
+  return callerOwnedFolders(meta).some(
+    (owned) => normalized === owned || normalized.startsWith(`${owned}/`)
+  );
+}
+
+const minioStub: ServiceSchema = {
+  name: 'minio',
+  actions: {
+    signStoredUrl: {
+      params: { url: 'string' },
+      visibility: 'protected',
+      handler(ctx: any) {
+        const { url } = ctx.params;
+        if (!url || typeof url !== 'string') return url;
+        const idx = url.indexOf('/minio/');
+        if (idx === -1) return url;
+        const rest = url.slice(idx + '/minio/'.length);
+        const [bucketName, ...objectParts] = rest.split('/');
+        const objectName = objectParts.join('/');
+        if (!bucketName || !objectName) return url;
+        if (!isFolderOwnedByCaller(objectName, ctx.meta)) return url;
+        return `${url}${url.includes('?') ? '&' : '?'}X-Amz-Signature=test-stub`;
+      },
+    },
+    uploadFile: {
+      visibility: 'protected',
+      handler(ctx: any) {
+        const folder = ctx.params?.folder || 'uploads/tmp/x/x';
+        const name = ctx.params?.name || 'stub';
+        const path = `${folder}/${name}.bin`;
+        return {
+          url: `http://localhost:9000/minio/uetk-test/${path}`,
+          path: `uetk-test/${path}`,
+          filename: ctx.meta?.filename,
+          size: 100,
+        };
+      },
+    },
+    getFile: { handler: () => Buffer.from('stub') },
+    removeFile: { handler: () => ({ success: true }) },
+    fileStat: { handler: () => ({ exists: false }) },
+    getUrl: { handler: () => 'http://localhost:9000/stub' },
+    putObject: { handler: () => ({}) },
+    getObject: { handler: () => Buffer.from('stub') },
+    statObject: { handler: () => ({ size: 100 }) },
+    removeObject: { handler: () => ({}) },
+    presignedUrl: { handler: () => 'http://localhost:9000/presigned-stub' },
+  },
+};
+
+// External auth service stub. Returns canned values for the handful of calls
+// the real services make.
+const authStub: ServiceSchema = {
+  name: 'auth',
+  actions: {
+    'users.resolveToken': { handler: () => null },
+    'users.get': { handler: () => ({}) },
+    'users.invite': {
+      handler: (ctx: any) => ({
+        id: Math.floor(Math.random() * 1e9),
+        firstName: 'Stub',
+        lastName: 'Auth',
+        email: ctx.params?.notify?.[0] || 'stub@test',
+        type: 'USER',
+      }),
+    },
+    'users.assignToGroup': { handler: () => ({ success: true }) },
+    'users.unassignFromGroup': { handler: () => ({ success: true }) },
+    'users.remove': { handler: () => ({ success: true }) },
+    'users.logout': { handler: () => ({ success: true }) },
+    'groups.get': { handler: () => ({ id: 1, name: 'stub-group', role: 'USER' }) },
+    'groups.remove': { handler: () => ({ success: true }) },
+    'apps.resolveToken': { handler: () => ({ id: 1, name: 'uetk-test' }) },
+    validateType: {
+      handler: (ctx: any) => {
+        const types: string[] = ctx.params?.types || [];
+        const { user, profile } = ctx.meta || {};
+        if (!types?.length) return true;
+        let ok = false;
+        if (types.includes('ADMIN')) ok = ok || user?.type === 'ADMIN';
+        if (types.includes('USER')) ok = ok || user?.type === 'USER';
+        if (types.includes('TENANT_ADMIN'))
+          ok = ok || profile?.role === 'ADMIN';
+        if (types.includes('TENANT_USER')) ok = ok || !!profile?.id;
+        return ok;
+      },
+    },
+  },
+};
+
+// Objects service stub — the real one queries the GIS DB (PostGIS publishing
+// schema) which we don't ship in test fixtures. Tests that need objects can
+// stub more deeply per-spec.
+const objectsStub: ServiceSchema = {
+  name: 'objects',
+  actions: {
+    find: { handler: () => [] },
+    list: {
+      handler: () => ({
+        rows: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+        totalPages: 0,
+      }),
+    },
+    findOne: { handler: () => null },
+    search: { handler: () => ({ rows: [], total: 0 }) },
+  },
+};
+
+// Tools stub for SSRF allowlist tests we exercise through the real
+// tools.service action — see search.spec.ts. Not used by default.
+
+/**
+ * Build a broker wired with the security-relevant services + stubs.
+ *
+ * Caller is responsible for `broker.start()` and `broker.stop()`. Migrations
+ * are NOT automatic — call `runMigrations()` separately before broker.start().
+ */
+export function buildBroker() {
+  const broker = new ServiceBroker({
+    logger: { type: 'Console', options: { level: 'warn' } },
+    cacher: 'Memory',
+    transporter: null as any,
+  });
+
+  // Stubs MUST be registered before real services if there are name collisions
+  // (broker.createService is order-sensitive only for the last-wins case;
+  // we register stubs first to be explicit).
+  broker.createService(authStub);
+  broker.createService(minioStub);
+  broker.createService(objectsStub);
+
+  broker.createService(UsersService);
+  broker.createService(TenantsService);
+  broker.createService(TenantUsersService);
+  broker.createService(RequestsService);
+  broker.createService(RequestsHistoriesService);
+  broker.createService(FormsService);
+  broker.createService(FormsHistoriesService);
+
+  return broker;
+}
+
+/**
+ * Wipe + migrate the test database. Idempotent. Run once before broker.start
+ * in beforeAll.
+ */
+export async function runMigrations() {
+  const k = knex(knexConfig);
+  try {
+    // Drop+recreate test tables. We only touch tables we know about so a
+    // shared dev DB doesn't get nuked.
+    const tablesInReverseOrder = [
+      'forms_histories',
+      'requests_histories',
+      'forms',
+      'requests',
+      'tenant_users',
+      'tenants',
+      'users',
+      'migrations',
+      'migrations_lock',
+    ];
+    for (const t of tablesInReverseOrder) {
+      await k.schema.dropTableIfExists(t);
+    }
+    await k.migrate.latest();
+  } finally {
+    await k.destroy();
+  }
+}
+
+/** Meta to call actions as a regular user. */
+export function userMeta(user: { id: number; type?: string; firstName?: string; lastName?: string; email?: string }) {
+  return {
+    user: {
+      id: user.id,
+      type: user.type || 'USER',
+      firstName: user.firstName || 'Test',
+      lastName: user.lastName || 'User',
+      email: user.email || 'user@test',
+    },
+    profile: undefined as any,
+  };
+}
+
+/** Meta to call actions as an admin. */
+export function adminMeta(adminId = 1) {
+  return {
+    user: {
+      id: adminId,
+      type: 'ADMIN',
+      firstName: 'Test',
+      lastName: 'Admin',
+      email: 'admin@test',
+    },
+    profile: undefined as any,
+  };
+}
+
+/** Meta to call actions as a tenant user / admin. */
+export function tenantMeta(
+  user: { id: number; type?: string },
+  tenant: { id: number; role: 'USER' | 'ADMIN' }
+) {
+  return {
+    user: { id: user.id, type: user.type || 'USER' },
+    profile: { id: tenant.id, role: tenant.role },
+  };
+}
+
+/** Seed a baseline set of users + tenants used across specs. */
+export async function seedBaseline(broker: ServiceBroker) {
+  const admin: any = await broker.call(
+    'users.create',
+    {
+      firstName: 'Test',
+      lastName: 'Admin',
+      email: 'admin@test',
+      type: 'ADMIN',
+      authUser: 1001,
+    }
+  );
+  const userA: any = await broker.call('users.create', {
+    firstName: 'User',
+    lastName: 'A',
+    email: 'user-a@test',
+    type: 'USER',
+    authUser: 2001,
+  });
+  const userB: any = await broker.call('users.create', {
+    firstName: 'User',
+    lastName: 'B',
+    email: 'user-b@test',
+    type: 'USER',
+    authUser: 2002,
+  });
+  const tenant: any = await broker.call('tenants.create', {
+    name: 'Test Tenant',
+    email: 'tenant@test',
+    code: 'test-tenant',
+    authGroup: 9001,
+  });
+  await broker.call('tenantUsers.create', {
+    tenant: tenant.id,
+    user: userA.id,
+    role: 'ADMIN',
+  });
+  return { admin, userA, userB, tenant };
+}

--- a/test/helpers/broker.ts
+++ b/test/helpers/broker.ts
@@ -198,28 +198,22 @@ export function buildBroker() {
 export async function runMigrations() {
   const k = knex(knexConfig);
   try {
-    const tablesInReverseOrder = [
-      'forms_histories',
-      'requests_histories',
-      'forms',
-      'requests',
-      'tenant_users',
-      'tenants',
-      'users',
-      'migrations',
-      'migrations_lock',
-    ];
-    for (const t of tablesInReverseOrder) {
-      await k.schema.dropTableIfExists(t);
-    }
-    // Drop every user-defined enum in the public schema so re-running
-    // migrations within a single Jest process doesn't trip on
-    // `type "..." already exists`. Hard-coding the list is fragile — new
-    // migrations add new enums (tenant_user_role was the one we missed).
+    // Drop every non-PostGIS table + enum in the public schema. Hard-coding
+    // the lists kept missing new tables / types when migrations grow (we hit
+    // form_histories, tenant_user_role). PostGIS owns spatial_ref_sys + its
+    // helper tables under public — skip those, dropping them breaks the
+    // extension.
     await k.raw(`
       DO $$
       DECLARE r RECORD;
       BEGIN
+        FOR r IN (
+          SELECT tablename FROM pg_tables
+          WHERE schemaname = 'public'
+            AND tablename NOT IN ('spatial_ref_sys', 'geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews')
+        ) LOOP
+          EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
+        END LOOP;
         FOR r IN (
           SELECT t.typname
           FROM pg_type t

--- a/test/helpers/broker.ts
+++ b/test/helpers/broker.ts
@@ -152,6 +152,19 @@ const objectsStub: ServiceSchema = {
   },
 };
 
+// Background-jobs stub. requests.updated event handler invokes
+// requests.generatePdf -> jobs.requests.initiatePdfGenerate when the status
+// transitions to APPROVED. The real service uses BullMQ + Redis; we don't
+// need the side-effect for security testing, just the action to exist.
+const jobsRequestsStub: ServiceSchema = {
+  name: 'jobs.requests',
+  actions: {
+    initiatePdfGenerate: { handler: () => ({ job: { id: 'stub-job' } }) },
+    generateAndSavePdf: { handler: () => ({ job: { id: 'stub-job' } }) },
+    getRequestHtml: { handler: () => '<html></html>' },
+  },
+};
+
 // Tools stub for SSRF allowlist tests we exercise through the real
 // tools.service action — see search.spec.ts. Not used by default.
 
@@ -174,6 +187,7 @@ export function buildBroker() {
   broker.createService(authStub);
   broker.createService(minioStub);
   broker.createService(objectsStub);
+  broker.createService(jobsRequestsStub);
 
   broker.createService(UsersService);
   broker.createService(TenantsService);

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Test runtime: every env var that the services read on import must be set
+// here. The values point at the CI / docker-compose Postgres + Redis services
+// and fake out anything that would otherwise reach an external system
+// (biip-auth, MinIO, tools-host).
+process.env.NODE_ENV = 'test';
+process.env.PORT = '0';
+
+process.env.AUTH_HOST = 'http://stub-auth.test';
+process.env.AUTH_API_KEY = 'test';
+process.env.APP_HOST = 'https://test-uetk.biip.lt';
+process.env.SERVER_HOST = 'http://localhost:3000';
+process.env.MAPS_HOST = 'https://maps.biip.lt';
+process.env.TOOLS_HOST = 'http://stub-tools.test';
+process.env.QGIS_SERVER_HOST = 'https://gis.biip.lt';
+
+process.env.DB_CONNECTION =
+  process.env.DB_CONNECTION ||
+  'postgresql://postgres:postgres@localhost:5436/uetk_test';
+process.env.GIS_DB_CONNECTION =
+  process.env.GIS_DB_CONNECTION || process.env.DB_CONNECTION;
+
+process.env.REDIS_CONNECTION =
+  process.env.REDIS_CONNECTION || 'redis://localhost:6671';
+
+process.env.MINIO_ACCESSKEY = 'minioadmin';
+process.env.MINIO_SECRETKEY = 'minioadmin';
+process.env.MINIO_BUCKET = 'uetk-test';
+process.env.MINIO_ENDPOINT = 'localhost';
+process.env.MINIO_PORT = '9000';
+process.env.MINIO_USESSL = 'false';
+process.env.MINIO_PUBLIC_URL = 'http://localhost:9000';
+
+// HMAC key for getRequestSecret. Tests assert HMAC mode is on, so this must
+// not be empty.
+process.env.REQUEST_SECRET = 'test-request-secret-please-rotate-in-prod';

--- a/test/helpers/stub-postmark.js
+++ b/test/helpers/stub-postmark.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Stub used in tests via jest.config.js moduleNameMapper. Postmark ships as
+// ESM-only since v4, which Jest 27 + ts-jest 27 (CommonJS) cannot parse. Mail
+// flows aren't part of any security test, so we hand them a no-op client.
+
+class ServerClient {
+  constructor() {}
+  sendEmailWithTemplate() {
+    return Promise.resolve({});
+  }
+  sendEmail() {
+    return Promise.resolve({});
+  }
+}
+
+module.exports = { ServerClient };
+module.exports.ServerClient = ServerClient;
+module.exports.default = { ServerClient };

--- a/test/integration/security/crypto.spec.ts
+++ b/test/integration/security/crypto.spec.ts
@@ -1,0 +1,44 @@
+'use strict';
+
+import { createHmac } from 'crypto';
+import moment from 'moment';
+import { getRequestSecret } from '../../../utils/functions';
+
+describe('getRequestSecret (HMAC mode)', () => {
+  const createdAt = '2026-05-27T12:00:00.000Z';
+  const request = { id: 42, createdAt };
+
+  it('returns an HMAC-SHA256 hex digest when REQUEST_SECRET is set', () => {
+    const got = getRequestSecret(request);
+    expect(got).toMatch(/^[a-f0-9]{64}$/);
+
+    const payload = `id=${request.id}&date=${moment(createdAt).format(
+      'YYYYMMDDHHmmss'
+    )}`;
+    const expected = createHmac('sha256', process.env.REQUEST_SECRET as string)
+      .update(payload)
+      .digest('hex');
+    expect(got).toBe(expected);
+  });
+
+  it('changes when REQUEST_SECRET changes — defeats the prior brute force', () => {
+    const original = process.env.REQUEST_SECRET;
+    const a = getRequestSecret(request);
+    process.env.REQUEST_SECRET = `${original}-rotated`;
+    const b = getRequestSecret(request);
+    process.env.REQUEST_SECRET = original;
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to MD5 only when REQUEST_SECRET is unset (dev convenience)', () => {
+    const original = process.env.REQUEST_SECRET;
+    delete process.env.REQUEST_SECRET;
+    try {
+      const got = getRequestSecret(request);
+      // MD5 is 32 hex chars; the HMAC mode returns 64.
+      expect(got).toMatch(/^[a-f0-9]{32}$/);
+    } finally {
+      if (original !== undefined) process.env.REQUEST_SECRET = original;
+    }
+  });
+});

--- a/test/integration/security/getRequestGeom.spec.ts
+++ b/test/integration/security/getRequestGeom.spec.ts
@@ -1,0 +1,79 @@
+'use strict';
+
+import { ServiceBroker } from 'moleculer';
+import {
+  buildBroker,
+  runMigrations,
+  seedBaseline,
+  userMeta,
+  adminMeta,
+} from '../../helpers/broker';
+
+describe('requests.getRequestGeom — no longer leaks geometry to anonymous callers', () => {
+  let broker: ServiceBroker;
+  let admin: any;
+  let userA: any;
+  let userB: any;
+  let bRequestId: number;
+
+  beforeAll(async () => {
+    await runMigrations();
+    broker = buildBroker();
+    await broker.start();
+    ({ admin, userA, userB } = await seedBaseline(broker));
+
+    const bRecord: any = await broker.call(
+      'requests.create',
+      {
+        purpose: 'OTHER',
+        purposeValue: 'secret-geom-owner-b',
+        objects: [{ id: '7', type: 'CADASTRAL_ID' }],
+      },
+      { meta: userMeta(userB) }
+    );
+    bRequestId = bRecord.id;
+  }, 120000);
+
+  afterAll(async () => {
+    if (broker) await broker.stop();
+  });
+
+  it('returns empty geom when called with no user meta', async () => {
+    // The action body does ctx.call('requests.resolve', { id, populate: 'geom',
+    // throwIfNotExist: true }) — pre-fix the visibleToUser scope returned the
+    // raw query when ctx.meta.user was missing, so an unauthenticated PUBLIC
+    // alias leaked every request's geom. Post-fix the scope forces id=-1.
+    await expect(
+      broker.call('requests.getRequestGeom', { id: bRequestId })
+    ).rejects.toThrow();
+  });
+
+  it("returns empty for user A trying to read user B's geom", async () => {
+    await expect(
+      broker.call(
+        'requests.getRequestGeom',
+        { id: bRequestId },
+        { meta: userMeta(userA) }
+      )
+    ).rejects.toThrow();
+  });
+
+  it('returns the geom for the owner', async () => {
+    const got: any = await broker.call(
+      'requests.getRequestGeom',
+      { id: bRequestId },
+      { meta: userMeta(userB) }
+    );
+    // No geom was set on create, so we expect {} not an error.
+    expect(got).toEqual({});
+  });
+
+  it('returns the geom for an admin', async () => {
+    const got: any = await broker.call(
+      'requests.getRequestGeom',
+      { id: bRequestId },
+      { meta: adminMeta(admin.id) }
+    );
+    expect(got).toEqual({});
+  });
+});

--- a/test/integration/security/idor.spec.ts
+++ b/test/integration/security/idor.spec.ts
@@ -100,7 +100,7 @@ describe('IDOR write-side defenses', () => {
       expect(updated.generatedFile).toBeFalsy();
     });
 
-    it("allows system context (no user meta) to set generatedFile", async () => {
+    it("allows system context (no user meta) to set generatedFile via saveGeneratedPdf", async () => {
       const own: any = await broker.call(
         'requests.create',
         {
@@ -111,15 +111,25 @@ describe('IDOR write-side defenses', () => {
         { meta: userMeta(userA) }
       );
 
-      // Mimic jobs.requests.generateAndSavePdf -> ctx.call without user meta
+      // This is the real prod path: jobs.requests.generateAndSavePdf calls
+      // requests.saveGeneratedPdf in a background worker context with empty
+      // ctx.meta. saveGeneratedPdf passes scope: 'notDeleted' so visibleToUser
+      // deny-by-default doesn't block its own job.
       const systemUrl =
         `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userA.id}/job.pdf`;
-      const updated: any = await broker.call('requests.update', {
+      await broker.call('requests.saveGeneratedPdf', {
         id: own.id,
-        generatedFile: systemUrl,
+        url: systemUrl,
       });
 
-      expect(updated.generatedFile).toContain('/uploads/requests/private/');
+      // Verify via admin read since the user's visibleToUser scope sees only
+      // their own records — admin sees everyone.
+      const reread: any = await broker.call(
+        'requests.resolve',
+        { id: own.id },
+        { meta: adminMeta(admin.id) }
+      );
+      expect(reread.generatedFile).toContain('/uploads/requests/private/');
     });
 
     it("allows admin to set generatedFile via an APPROVE transition", async () => {

--- a/test/integration/security/idor.spec.ts
+++ b/test/integration/security/idor.spec.ts
@@ -101,6 +101,8 @@ describe('IDOR write-side defenses', () => {
     });
 
     it("allows system context (no user meta) to set generatedFile via saveGeneratedPdf", async () => {
+      // saveGeneratedPdf only writes for status=APPROVED — admin approves
+      // the request first, then the background worker calls saveGeneratedPdf.
       const own: any = await broker.call(
         'requests.create',
         {
@@ -110,11 +112,12 @@ describe('IDOR write-side defenses', () => {
         },
         { meta: userMeta(userA) }
       );
+      await broker.call(
+        'requests.update',
+        { id: own.id, status: 'APPROVED' },
+        { meta: adminMeta(admin.id) }
+      );
 
-      // This is the real prod path: jobs.requests.generateAndSavePdf calls
-      // requests.saveGeneratedPdf in a background worker context with empty
-      // ctx.meta. saveGeneratedPdf passes scope: 'notDeleted' so visibleToUser
-      // deny-by-default doesn't block its own job.
       const systemUrl =
         `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userA.id}/job.pdf`;
       await broker.call('requests.saveGeneratedPdf', {
@@ -122,14 +125,31 @@ describe('IDOR write-side defenses', () => {
         url: systemUrl,
       });
 
-      // Verify via admin read since the user's visibleToUser scope sees only
-      // their own records — admin sees everyone.
       const reread: any = await broker.call(
         'requests.resolve',
         { id: own.id },
         { meta: adminMeta(admin.id) }
       );
       expect(reread.generatedFile).toContain('/uploads/requests/private/');
+    });
+
+    it("rejects saveGeneratedPdf on a non-APPROVED request", async () => {
+      const own: any = await broker.call(
+        'requests.create',
+        {
+          purpose: 'OTHER',
+          purposeValue: 'wrong-state',
+          objects: [{ id: '88', type: 'CADASTRAL_ID' }],
+        },
+        { meta: userMeta(userA) }
+      );
+
+      await expect(
+        broker.call('requests.saveGeneratedPdf', {
+          id: own.id,
+          url: 'http://localhost:3000/minio/uetk-test/uploads/requests/private/4/x.pdf',
+        })
+      ).rejects.toThrow();
     });
 
     it("allows admin to set generatedFile via an APPROVE transition", async () => {

--- a/test/integration/security/idor.spec.ts
+++ b/test/integration/security/idor.spec.ts
@@ -122,7 +122,7 @@ describe('IDOR write-side defenses', () => {
       expect(updated.generatedFile).toContain('/uploads/requests/private/');
     });
 
-    it("allows admin to set generatedFile", async () => {
+    it("allows admin to set generatedFile via an APPROVE transition", async () => {
       const own: any = await broker.call(
         'requests.create',
         {
@@ -137,11 +137,13 @@ describe('IDOR write-side defenses', () => {
         `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userA.id}/admin.pdf`;
       const updated: any = await broker.call(
         'requests.update',
-        { id: own.id, generatedFile: adminUrl },
+        { id: own.id, generatedFile: adminUrl, status: 'APPROVED' },
         { meta: adminMeta(admin.id) }
       );
 
-      // Admin set is allowed; read may have a stub-signed suffix appended
+      // Admin set is allowed; the stub minio.signStoredUrl appends a fake
+      // X-Amz-Signature=... so the substring containing the original path is
+      // enough to confirm the field was written.
       expect(updated.generatedFile).toContain('admin.pdf');
     });
   });
@@ -162,7 +164,16 @@ describe('IDOR write-side defenses', () => {
           objectName: 'IDOR forms test',
           providerType: 'OWNER',
           description: 'x',
-          geom: null,
+          geom: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [500000, 6000000] },
+                properties: {},
+              },
+            ],
+          },
           files: [
             { url: ownUrl, filename: 'own.pdf' },
             { url: victimUrl, filename: 'stolen.pdf' },
@@ -190,7 +201,16 @@ describe('IDOR write-side defenses', () => {
           objectName: 'traversal test',
           providerType: 'OWNER',
           description: 'x',
-          geom: null,
+          geom: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [500000, 6000000] },
+                properties: {},
+              },
+            ],
+          },
           files: [{ url: traversal, filename: 'escape.pdf' }],
         },
         { meta: userMeta(userA) }
@@ -211,7 +231,16 @@ describe('IDOR write-side defenses', () => {
           objectName: 'tenant test',
           providerType: 'OWNER',
           description: 'x',
-          geom: null,
+          geom: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [500000, 6000000] },
+                properties: {},
+              },
+            ],
+          },
           files: [{ url: tenantUrl, filename: 'tenant-file.pdf' }],
         },
         { meta: tenantMeta(userA, { id: tenant.id, role: 'ADMIN' }) }

--- a/test/integration/security/idor.spec.ts
+++ b/test/integration/security/idor.spec.ts
@@ -1,0 +1,223 @@
+'use strict';
+
+import { ServiceBroker } from 'moleculer';
+import {
+  buildBroker,
+  runMigrations,
+  seedBaseline,
+  userMeta,
+  adminMeta,
+  tenantMeta,
+} from '../../helpers/broker';
+
+describe('IDOR write-side defenses', () => {
+  let broker: ServiceBroker;
+  let admin: any;
+  let userA: any;
+  let userB: any;
+  let tenant: any;
+
+  beforeAll(async () => {
+    await runMigrations();
+    broker = buildBroker();
+    await broker.start();
+    ({ admin, userA, userB, tenant } = await seedBaseline(broker));
+  }, 120000);
+
+  afterAll(async () => {
+    if (broker) await broker.stop();
+  });
+
+  describe('requests.generatedFile', () => {
+    it("blocks a regular user from setting generatedFile on create", async () => {
+      const malicious =
+        `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userB.id}/victim.pdf`;
+
+      const created: any = await broker.call(
+        'requests.create',
+        {
+          purpose: 'OTHER',
+          purposeValue: 'idor',
+          objects: [{ id: '12345', type: 'CADASTRAL_ID' }],
+          generatedFile: malicious,
+        },
+        { meta: userMeta(userA) }
+      );
+
+      expect(created).toBeTruthy();
+      expect(created.id).toBeGreaterThan(0);
+      expect(created.generatedFile).toBeFalsy();
+    });
+
+    it("blocks a regular user from updating generatedFile on their own request", async () => {
+      // Pre-seed a request as the user normally would
+      const own: any = await broker.call(
+        'requests.create',
+        {
+          purpose: 'OTHER',
+          purposeValue: 'baseline',
+          objects: [{ id: '99', type: 'CADASTRAL_ID' }],
+        },
+        { meta: userMeta(userA) }
+      );
+      expect(own.generatedFile).toBeFalsy();
+
+      const victimUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userB.id}/v.pdf`;
+
+      // Direct call to updateEntity-equivalent: requests.update on own id.
+      // We bypass the validateStatusChange edge case (which forces status=SUBMITTED
+      // and rejects edits on CREATED) by NOT providing an id in params — instead
+      // call the underlying database update via a known status (RETURNED is
+      // editable). To keep things action-level we use updateEntity directly.
+      await broker.call(
+        '$node.actions',
+        {},
+        { meta: userMeta(userA) }
+      ); // sanity that broker is alive
+
+      // Force the request to RETURNED status as admin so the user can edit it
+      await broker.call(
+        'requests.update',
+        { id: own.id, status: 'RETURNED' },
+        { meta: adminMeta(admin.id) }
+      );
+
+      // Now user updates with a malicious generatedFile in payload
+      const updated: any = await broker.call(
+        'requests.update',
+        {
+          id: own.id,
+          generatedFile: victimUrl,
+          status: 'SUBMITTED', // user's allowed transition out of RETURNED
+        },
+        { meta: userMeta(userA) }
+      );
+
+      expect(updated.id).toBe(own.id);
+      // The set hook returned entity?.generatedFile (was undefined before),
+      // so the malicious URL never lands in storage.
+      expect(updated.generatedFile).toBeFalsy();
+    });
+
+    it("allows system context (no user meta) to set generatedFile", async () => {
+      const own: any = await broker.call(
+        'requests.create',
+        {
+          purpose: 'OTHER',
+          purposeValue: 'system test',
+          objects: [{ id: '77', type: 'CADASTRAL_ID' }],
+        },
+        { meta: userMeta(userA) }
+      );
+
+      // Mimic jobs.requests.generateAndSavePdf -> ctx.call without user meta
+      const systemUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userA.id}/job.pdf`;
+      const updated: any = await broker.call('requests.update', {
+        id: own.id,
+        generatedFile: systemUrl,
+      });
+
+      expect(updated.generatedFile).toContain('/uploads/requests/private/');
+    });
+
+    it("allows admin to set generatedFile", async () => {
+      const own: any = await broker.call(
+        'requests.create',
+        {
+          purpose: 'OTHER',
+          purposeValue: 'admin test',
+          objects: [{ id: '55', type: 'CADASTRAL_ID' }],
+        },
+        { meta: userMeta(userA) }
+      );
+
+      const adminUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/requests/private/${userA.id}/admin.pdf`;
+      const updated: any = await broker.call(
+        'requests.update',
+        { id: own.id, generatedFile: adminUrl },
+        { meta: adminMeta(admin.id) }
+      );
+
+      // Admin set is allowed; read may have a stub-signed suffix appended
+      expect(updated.generatedFile).toContain('admin.pdf');
+    });
+  });
+
+  describe('forms.files filter', () => {
+    it('drops files[].url entries that point outside the caller folder', async () => {
+      const ownUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/forms/private/${userA.id}/own.pdf`;
+      const victimUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/forms/private/${userB.id}/victim.pdf`;
+      const externalUrl = 'https://external.com/anything.pdf';
+
+      const form: any = await broker.call(
+        'forms.create',
+        {
+          type: 'NEW',
+          objectType: 'POND',
+          objectName: 'IDOR forms test',
+          providerType: 'OWNER',
+          description: 'x',
+          geom: null,
+          files: [
+            { url: ownUrl, filename: 'own.pdf' },
+            { url: victimUrl, filename: 'stolen.pdf' },
+            { url: externalUrl, filename: 'ext.pdf' },
+          ],
+        },
+        { meta: userMeta(userA) }
+      );
+
+      expect(form.id).toBeGreaterThan(0);
+      const urls = (form.files || []).map((f: any) => f.url);
+      expect(urls.some((u: string) => u.includes('own.pdf'))).toBe(true);
+      expect(urls.some((u: string) => u.includes('anything.pdf'))).toBe(true);
+      expect(urls.some((u: string) => u.includes('victim.pdf'))).toBe(false);
+    });
+
+    it("rejects path-traversal in files[].url", async () => {
+      const traversal =
+        `http://localhost:3000/minio/uetk-test/uploads/forms/private/${userA.id}/../${userB.id}/escape.pdf`;
+      const form: any = await broker.call(
+        'forms.create',
+        {
+          type: 'NEW',
+          objectType: 'POND',
+          objectName: 'traversal test',
+          providerType: 'OWNER',
+          description: 'x',
+          geom: null,
+          files: [{ url: traversal, filename: 'escape.pdf' }],
+        },
+        { meta: userMeta(userA) }
+      );
+
+      const urls = (form.files || []).map((f: any) => f.url);
+      expect(urls.some((u: string) => u.includes('escape.pdf'))).toBe(false);
+    });
+
+    it('accepts files inside the tenant folder for tenant admin', async () => {
+      const tenantUrl =
+        `http://localhost:3000/minio/uetk-test/uploads/forms/${tenant.id}/${userA.id}/tenant-file.pdf`;
+      const form: any = await broker.call(
+        'forms.create',
+        {
+          type: 'NEW',
+          objectType: 'POND',
+          objectName: 'tenant test',
+          providerType: 'OWNER',
+          description: 'x',
+          geom: null,
+          files: [{ url: tenantUrl, filename: 'tenant-file.pdf' }],
+        },
+        { meta: tenantMeta(userA, { id: tenant.id, role: 'ADMIN' }) }
+      );
+      const urls = (form.files || []).map((f: any) => f.url);
+      expect(urls.some((u: string) => u.includes('tenant-file.pdf'))).toBe(true);
+    });
+  });
+});

--- a/test/integration/security/scope.spec.ts
+++ b/test/integration/security/scope.spec.ts
@@ -1,0 +1,107 @@
+'use strict';
+
+import { ServiceBroker } from 'moleculer';
+import {
+  buildBroker,
+  runMigrations,
+  seedBaseline,
+  userMeta,
+  adminMeta,
+} from '../../helpers/broker';
+
+describe('visibleToUser scope: deny-by-default for unauthenticated callers', () => {
+  let broker: ServiceBroker;
+  let userA: any;
+  let userB: any;
+  let admin: any;
+
+  beforeAll(async () => {
+    await runMigrations();
+    broker = buildBroker();
+    await broker.start();
+    ({ admin, userA, userB } = await seedBaseline(broker));
+
+    // Seed one request per user so the scope has something to filter.
+    await broker.call(
+      'requests.create',
+      {
+        purpose: 'OTHER',
+        purposeValue: 'a',
+        objects: [{ id: '1', type: 'CADASTRAL_ID' }],
+      },
+      { meta: userMeta(userA) }
+    );
+    await broker.call(
+      'requests.create',
+      {
+        purpose: 'OTHER',
+        purposeValue: 'b',
+        objects: [{ id: '2', type: 'CADASTRAL_ID' }],
+      },
+      { meta: userMeta(userB) }
+    );
+  }, 120000);
+
+  afterAll(async () => {
+    if (broker) await broker.stop();
+  });
+
+  it('returns nothing for an unauthenticated caller', async () => {
+    // No user in meta at all — pre-fix the scope returned the unmodified
+    // query, leaking every record to any internal ctx.call from a PUBLIC
+    // action.
+    const list: any = await broker.call('requests.list', { pageSize: 100 });
+    expect(list.total).toBe(0);
+    expect(list.rows).toEqual([]);
+  });
+
+  it("scopes a USER to their own records only", async () => {
+    const list: any = await broker.call(
+      'requests.list',
+      { pageSize: 100 },
+      { meta: userMeta(userA) }
+    );
+    expect(list.total).toBe(1);
+    expect(list.rows[0].createdBy).toBe(userA.id);
+  });
+
+  it('lets an admin see everyone', async () => {
+    const list: any = await broker.call(
+      'requests.list',
+      { pageSize: 100 },
+      { meta: adminMeta(admin.id) }
+    );
+    expect(list.total).toBeGreaterThanOrEqual(2);
+  });
+
+  it("denies an unauthenticated caller a direct resolve by id", async () => {
+    // Pick userB's record by id
+    const all: any = await broker.call(
+      'requests.list',
+      { pageSize: 100 },
+      { meta: adminMeta(admin.id) }
+    );
+    const bRecord = all.rows.find((r: any) => r.createdBy === userB.id);
+    expect(bRecord).toBeTruthy();
+
+    const resolved = await broker.call('requests.resolve', { id: bRecord.id });
+    // pre-fix: returned the full record; post-fix: scope forces id=-1 so the
+    // resolve returns nothing.
+    expect(resolved).toBeFalsy();
+  });
+
+  it("denies user A from reading user B's request even by id", async () => {
+    const all: any = await broker.call(
+      'requests.list',
+      { pageSize: 100 },
+      { meta: adminMeta(admin.id) }
+    );
+    const bRecord = all.rows.find((r: any) => r.createdBy === userB.id);
+    const resolvedAsA = await broker.call(
+      'requests.resolve',
+      { id: bRecord.id },
+      { meta: userMeta(userA) }
+    );
+    expect(resolvedAsA).toBeFalsy();
+  });
+});

--- a/test/integration/security/ssrf.spec.ts
+++ b/test/integration/security/ssrf.spec.ts
@@ -1,0 +1,44 @@
+'use strict';
+
+import { assertSafeToolUrl } from '../../../services/tools.service';
+
+describe('tools.assertSafeToolUrl — SSRF allowlist', () => {
+  const allowedDevHost = 'localhost:3000';
+
+  it('accepts URLs on the SERVER_HOST allowlist', () => {
+    expect(() =>
+      assertSafeToolUrl(`http://${allowedDevHost}/jobs/requests/1/html?secret=x`)
+    ).not.toThrow();
+  });
+
+  it('accepts URLs on the MAPS_HOST allowlist', () => {
+    expect(() => assertSafeToolUrl('https://maps.biip.lt/uetk')).not.toThrow();
+  });
+
+  it('rejects AWS / GCP metadata IPs', () => {
+    expect(() =>
+      assertSafeToolUrl('http://169.254.169.254/latest/meta-data/')
+    ).toThrow(/Host not allowed/);
+    expect(() =>
+      assertSafeToolUrl('http://metadata.google.internal/computeMetadata/v1/')
+    ).toThrow(/Host not allowed/);
+  });
+
+  it('rejects arbitrary external hosts', () => {
+    expect(() => assertSafeToolUrl('https://attacker.com/foo')).toThrow(
+      /Host not allowed/
+    );
+  });
+
+  it('rejects non-http schemes', () => {
+    expect(() => assertSafeToolUrl('file:///etc/passwd')).toThrow(/http/);
+    expect(() => assertSafeToolUrl('gopher://internal/whatever')).toThrow(
+      /http/
+    );
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(() => assertSafeToolUrl('not-a-url')).toThrow(/Invalid URL/);
+    expect(() => assertSafeToolUrl('')).toThrow();
+  });
+});

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, createHmac } from 'crypto';
 import moment from 'moment';
 import { Readable } from 'stream';
 
@@ -48,12 +48,22 @@ export function parseToJsonIfNeeded(query: QueryObject | string): QueryObject {
   return query as QueryObject;
 }
 
+/**
+ * HMAC of (request id + createdAt) signed by a server-side secret. Replaces an
+ * earlier MD5(id+createdAt) scheme that was brute-forceable given a known
+ * request ID + creation window (~86k MD5/s on a laptop). Falls back to the old
+ * scheme only if REQUEST_SECRET is missing, so dev environments without the
+ * env var still work; production must set REQUEST_SECRET.
+ */
 export function getRequestSecret(request: any) {
-  return toMD5Hash(
-    `id=${request.id}&date=${moment(request.createdAt).format(
-      'YYYYMMDDHHmmss'
-    )}`
-  );
+  const payload = `id=${request.id}&date=${moment(request.createdAt).format(
+    'YYYYMMDDHHmmss'
+  )}`;
+  const key = process.env.REQUEST_SECRET;
+  if (key) {
+    return createHmac('sha256', key).update(payload).digest('hex');
+  }
+  return toMD5Hash(payload);
 }
 
 export function addLeadingZeros(num: number, totalLength: number = 7) {


### PR DESCRIPTION
## Summary

End-to-end pass against findings from the `/cso` audit run on this repo. One PR, broken into logical blocks below, all behind the same defense-in-depth approach (auth at route + scope at DB + ownership check at storage).

Highlights:
- Unauthenticated PDF / GeoJSON / form-attachment leak via `minio.getFile` + `requests.getRequestGeom` closed.
- `mappingPolicy: 'all'` -> `'restrict'` so internal actions stop being reachable via fallback URLs like `/uetk/<service>/<action>`.
- MD5(id + createdAt) PDF "secret" replaced with HMAC-SHA256 keyed by `REQUEST_SECRET`.
- `tools.*` (PDF / screenshot / download) gained a host allowlist - removes the SSRF reflector that pointed at internal IPs.
- `objects.search` $raw string concat replaced with parameterized knex bindings.
- `search.search` user-controlled `new RegExp(search)` swapped for substring match (ReDoS).

## What changes for FE

Nothing visible:
- `requests.generatedFile` and `forms.files[].url` are now signed on read via a new `minio.signStoredUrl` action. FE still gets a URL it can put straight into `<a href={url}>` (no Authorization header needed).
- All existing REST routes (`GET /requests`, `GET /forms`, `PATCH /requests/:id`, etc.) continue to work via `autoAliases`, which reads each action's `rest:` property. Internal-only actions without `rest:` are now correctly unreachable.

## Test plan

Deploy to dev. Hand over admin + user tokens and we walk through:

- [ ] User: list own requests, open one, click generated PDF/GeoJSON download (presigned URL flow).
- [ ] User: create new request, generate PDF, download, then verify another user (other tenant) cannot see / download it.
- [ ] User: enumerate `/requests/<other-user-id>/geom` -> 401/empty (was leaking).
- [ ] User: hit `POST /public/cache/clean` -> 401 (was PUBLIC).
- [ ] Admin: review queue (list forms / requests), approve/reject, PDF download via `/requests/:id/pdf`.
- [ ] Admin: invite tenant + tenant user, update role, remove user.
- [ ] Hit `GET /uetk/users/findOrCreate` (or any internal action without rest:) -> 404 (mappingPolicy restrict).
- [ ] Hit `GET /uetk/tools/download?url=http://169.254.169.254/...` -> 400 (SSRF allowlist).
- [ ] Smoke: `objects.search?search=test`, `search.search?search=test%20river`, `objects/public/statistics` still work.
- [ ] Make sure `REQUEST_SECRET` is set in biip-infra dev env, otherwise PDF flow falls back to MD5 path (dev-only).

## Notes for biip-infra

- New env var: `REQUEST_SECRET` (production must set). Without it the code falls back to the legacy MD5 scheme so deploys don't break, but the brute-force window is back.
- Optional env var: `TOOLS_ALLOWED_HOSTS` (comma-separated extra hosts for `tools.*`). Defaults pick up `MAPS_HOST`, `SERVER_HOST`, `APP_HOST`, `QGIS_SERVER_HOST` automatically.

## Out of scope (intentionally not in this PR)

- CORS origin allowlist (kept `origin: '*'` per request - Bearer-token API, no cookies, no CSRF surface).
- DB-stored request access token + URL-header migration. The HMAC fix is enough to kill the practical brute force; full migration can be a follow-up.
- 74 npm advisories Dependabot is reporting on `main` - separate hardening pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>