### PR TITLE
Add Geodatabase (GDB) extract format for requests

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -14,6 +14,7 @@ import {
   toReadableStream,
 } from '../utils';
 import { AuthType } from './api.service';
+import { UETKObject } from './objects.service';
 import { Request } from './requests.service';
 import { Tenant } from './tenants.service';
 import { User } from './users.service';
@@ -105,6 +106,123 @@ export default class JobsRequestsService extends moleculer.Service {
     });
 
     return { job: job.id };
+  }
+
+  @Action({
+    queue: true,
+    params: {
+      id: 'number',
+    },
+    timeout: 0,
+  })
+  async generateAndSaveGdb(ctx: Context<{ id: number }>) {
+    const { id } = ctx.params;
+
+    const request: Request = await ctx.call('requests.resolve', {
+      id,
+      populate: 'createdBy,tenant,geom',
+    });
+
+    if (!request?.id) return { skipped: 'no-request' };
+
+    const cadastralIds = request.objects
+      ?.filter((i) => i.type === 'CADASTRAL_ID')
+      ?.map((i) => i.id)
+      ?.filter((i) => !!i);
+
+    const query: any = {};
+    if (cadastralIds?.length) query.cadastralId = { $in: cadastralIds };
+    if (request.geom && Object.keys(request.geom).length) query.geom = request.geom;
+
+    if (!query.cadastralId && !query.geom) return { skipped: 'no-objects' };
+
+    const objects: UETKObject[] = await ctx.call('objects.find', {
+      query,
+      populate: 'geom',
+    });
+
+    // flatMap so multi-geometry objects emit one Feature per inner geometry.
+    const features = objects.flatMap((obj: any) => {
+      const baseProps = {
+        cadastralId: obj.cadastralId,
+        name: obj.name,
+        category: obj.category,
+        categoryTranslate: obj.categoryTranslate,
+        municipality: obj.municipality,
+        municipalityCode: obj.municipalityCode,
+        area: obj.area,
+        length: obj.length,
+      };
+      if (
+        obj.geom?.type === 'FeatureCollection' &&
+        Array.isArray(obj.geom.features)
+      ) {
+        return obj.geom.features
+          .filter((f: any) => f?.geometry?.type)
+          .map((f: any) => ({
+            type: 'Feature',
+            geometry: f.geometry,
+            properties: { ...baseProps, ...(f.properties || {}) },
+          }));
+      }
+      const geometry =
+        obj.geom?.geometry || (obj.geom?.type ? obj.geom : null);
+      if (!geometry?.type) return [];
+      return [{ type: 'Feature', geometry, properties: baseProps }];
+    });
+
+    if (!features.length) return { skipped: 'no-geometries' };
+
+    const geojson = { type: 'FeatureCollection', features };
+
+    // tools.makeGdb streams the ZIP back as a Node Readable (no buffering)
+    const stream: NodeJS.ReadableStream = await ctx.call('tools.makeGdb', {
+      geojson,
+      name: `israsas-${request.id}`,
+      srid: 3346,
+    });
+
+    const folder = this.getFolderName(
+      request?.createdBy as any as User,
+      request?.tenant as Tenant
+    );
+
+    const result: any = await ctx.call(
+      'minio.uploadFile',
+      {
+        payload: stream,
+        folder,
+        isPrivate: true,
+        types: ['application/zip', 'application/x-zip-compressed'],
+        name: `israsas-${request.id}`,
+      },
+      {
+        meta: {
+          mimetype: 'application/zip',
+          filename: `israsas-${request.id}.zip`,
+        },
+      }
+    );
+
+    await ctx.call('requests.saveGeneratedPdf', { id, url: result.url });
+
+    return { generated: true };
+  }
+
+  @Action({
+    params: {
+      id: 'number',
+    },
+    timeout: 0,
+  })
+  async initiateGdbGenerate(ctx: Context<{ id: number }>) {
+    // No screenshot children needed for GDB — single queued job with
+    // BullMQ retry semantics inherited from the mixin (5 attempts, 1s
+    // backoff). Mirrors initiatePdfGenerate but without the flow() step.
+    const job = await this.localQueue(ctx, 'generateAndSaveGdb', {
+      id: ctx.params.id,
+    });
+    return { job: { id: job.id } };
   }
 
   @Action({

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -9,6 +9,7 @@ import DbConnection from '../mixins/database.mixin';
 import { AuthType, UserAuthMeta } from './api.service';
 
 import moment from 'moment';
+import { Readable } from 'stream';
 import {
   BaseModelInterface,
   COMMON_DEFAULT_SCOPES,
@@ -53,6 +54,7 @@ export interface Request extends BaseModelInterface {
   tenant: number | Tenant;
   data?: {
     extended?: boolean;
+    format?: string;
   };
 }
 
@@ -69,6 +71,11 @@ export const PurposeTypes = {
   TECHNICAL_PROJECT: 'TECHNICAL_PROJECT',
   SCIENTIFIC_INVESTIGATION: 'SCIENTIFIC_INVESTIGATION',
   OTHER: 'OTHER',
+};
+
+export const RequestFormat = {
+  PDF: 'PDF',
+  GDB: 'GDB',
 };
 
 const VISIBLE_TO_USER_SCOPE = 'visibleToUser';
@@ -259,6 +266,11 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
             required: false,
             default: false,
           },
+          format: {
+            type: 'string',
+            required: false,
+            enum: Object.values(RequestFormat),
+          },
         },
       },
 
@@ -415,6 +427,110 @@ export default class RequestsService extends moleculer.Service {
     return {
       generating: !!flow?.job?.id,
     };
+  }
+
+  @Action({
+    params: {
+      id: { type: 'number', convert: true },
+    },
+    timeout: 0,
+  })
+  async generateGdb(ctx: Context<{ id: number }>) {
+    const { id } = ctx.params;
+
+    const request: Request = await ctx.call('requests.resolve', {
+      id,
+      populate: 'createdBy,tenant,geom',
+    });
+
+    if (!request?.id) return { generating: false };
+
+    const cadastralIds = request.objects
+      ?.filter((i) => i.type === 'CADASTRAL_ID')
+      ?.map((i) => i.id)
+      ?.filter((i) => !!i);
+
+    const query: any = {};
+    if (cadastralIds?.length) query.cadastralId = { $in: cadastralIds };
+    if (request.geom && Object.keys(request.geom).length) query.geom = request.geom;
+
+    if (!query.cadastralId && !query.geom) return { generating: false };
+
+    const objects: UETKObject[] = await ctx.call('objects.find', {
+      query,
+      populate: 'geom',
+    });
+
+    // Flatten every object's geometry into Features. flatMap so multi-geometry
+    // objects (FeatureCollection.geom) emit one Feature per inner geometry.
+    const features = objects.flatMap((obj: any) => {
+      const baseProps = {
+        cadastralId: obj.cadastralId,
+        name: obj.name,
+        category: obj.category,
+        categoryTranslate: obj.categoryTranslate,
+        municipality: obj.municipality,
+        municipalityCode: obj.municipalityCode,
+        area: obj.area,
+        length: obj.length,
+      };
+      if (
+        obj.geom?.type === 'FeatureCollection' &&
+        Array.isArray(obj.geom.features)
+      ) {
+        return obj.geom.features
+          .filter((f: any) => f?.geometry?.type)
+          .map((f: any) => ({
+            type: 'Feature',
+            geometry: f.geometry,
+            properties: { ...baseProps, ...(f.properties || {}) },
+          }));
+      }
+      const geometry =
+        obj.geom?.geometry || (obj.geom?.type ? obj.geom : null);
+      if (!geometry?.type) return [];
+      return [{ type: 'Feature', geometry, properties: baseProps }];
+    });
+
+    if (!features.length) return { generating: false };
+
+    const geojson = { type: 'FeatureCollection', features };
+
+    // Delegate the actual GeoJSON → File-Geodatabase → ZIP work to the
+    // internal tools service (biip-tools /gdb endpoint). Keeps GDAL out of
+    // this image.
+    const zipBuffer: Buffer = await ctx.call('tools.makeGdb', {
+      geojson,
+      name: `israsas-${request.id}`,
+      srid: 3346,
+    });
+
+    const folder = `uploads/requests/${
+      (request.tenant as Tenant)?.id || 'private'
+    }/${(request.createdBy as any as User)?.id || 'user'}`;
+
+    const stream = Readable.from(zipBuffer);
+
+    const result: any = await ctx.call(
+      'minio.uploadFile',
+      {
+        payload: stream,
+        folder,
+        isPrivate: true,
+        types: ['application/zip', 'application/x-zip-compressed'],
+        name: `israsas-${request.id}`,
+      },
+      {
+        meta: {
+          mimetype: 'application/zip',
+          filename: `israsas-${request.id}.zip`,
+        },
+      }
+    );
+
+    await ctx.call('requests.saveGeneratedPdf', { id, url: result.url });
+
+    return { generating: true };
   }
 
   @Action({
@@ -617,7 +733,11 @@ export default class RequestsService extends moleculer.Service {
 
     if (request.generatedFile) return;
 
-    this.broker.call('requests.generatePdf', { id: request.id });
+    if (request.data?.format === RequestFormat.GDB) {
+      this.broker.call('requests.generateGdb', { id: request.id });
+    } else {
+      this.broker.call('requests.generatePdf', { id: request.id });
+    }
     return request;
   }
 

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -9,7 +9,6 @@ import DbConnection from '../mixins/database.mixin';
 import { AuthType, UserAuthMeta } from './api.service';
 
 import moment from 'moment';
-import { Readable } from 'stream';
 import {
   BaseModelInterface,
   COMMON_DEFAULT_SCOPES,
@@ -324,10 +323,11 @@ async function validatePurposeValue({ params, value }: FieldHookCallback) {
         return query;
       },
       filterRequestData(query: any) {
-        // The web filter sends data: { extended: bool }. JSONB containment lets
-        // the filter match rows whose data column carries extra keys alongside
-        // extended (e.g. legacy 'format: GEOJSON' rows from before that
-        // extract type was retired) without the brittleness of jsonb '='.
+        // The web filter sends data: { extended: bool } or { format: 'GDB' }.
+        // JSONB containment lets the filter match rows whose data column
+        // carries extra keys alongside the filter (e.g. format:'GDB' rows
+        // also match an extended:false query, and legacy 'format: GEOJSON'
+        // rows still match), without the brittleness of jsonb '='.
         if (!query.data) return query;
         let value = query.data;
         if (typeof value === 'string') {
@@ -433,104 +433,22 @@ export default class RequestsService extends moleculer.Service {
     params: {
       id: { type: 'number', convert: true },
     },
+    rest: 'POST /:id/generate-gdb',
     timeout: 0,
   })
   async generateGdb(ctx: Context<{ id: number }>) {
-    const { id } = ctx.params;
-
-    const request: Request = await ctx.call('requests.resolve', {
-      id,
-      populate: 'createdBy,tenant,geom',
+    // Mirror generatePdf: delegate to jobs.requests so the actual GeoJSON
+    // assembly + tools.makeGdb + MinIO upload runs as a BullMQ job with
+    // automatic retry (5 attempts via bullmq settings). Without this,
+    // a transient tools-service outage would leave the request stuck in
+    // APPROVED with no generatedFile and no audit trail.
+    const flow: any = await ctx.call('jobs.requests.initiateGdbGenerate', {
+      id: ctx.params.id,
     });
 
-    if (!request?.id) return { generating: false };
-
-    const cadastralIds = request.objects
-      ?.filter((i) => i.type === 'CADASTRAL_ID')
-      ?.map((i) => i.id)
-      ?.filter((i) => !!i);
-
-    const query: any = {};
-    if (cadastralIds?.length) query.cadastralId = { $in: cadastralIds };
-    if (request.geom && Object.keys(request.geom).length) query.geom = request.geom;
-
-    if (!query.cadastralId && !query.geom) return { generating: false };
-
-    const objects: UETKObject[] = await ctx.call('objects.find', {
-      query,
-      populate: 'geom',
-    });
-
-    // Flatten every object's geometry into Features. flatMap so multi-geometry
-    // objects (FeatureCollection.geom) emit one Feature per inner geometry.
-    const features = objects.flatMap((obj: any) => {
-      const baseProps = {
-        cadastralId: obj.cadastralId,
-        name: obj.name,
-        category: obj.category,
-        categoryTranslate: obj.categoryTranslate,
-        municipality: obj.municipality,
-        municipalityCode: obj.municipalityCode,
-        area: obj.area,
-        length: obj.length,
-      };
-      if (
-        obj.geom?.type === 'FeatureCollection' &&
-        Array.isArray(obj.geom.features)
-      ) {
-        return obj.geom.features
-          .filter((f: any) => f?.geometry?.type)
-          .map((f: any) => ({
-            type: 'Feature',
-            geometry: f.geometry,
-            properties: { ...baseProps, ...(f.properties || {}) },
-          }));
-      }
-      const geometry =
-        obj.geom?.geometry || (obj.geom?.type ? obj.geom : null);
-      if (!geometry?.type) return [];
-      return [{ type: 'Feature', geometry, properties: baseProps }];
-    });
-
-    if (!features.length) return { generating: false };
-
-    const geojson = { type: 'FeatureCollection', features };
-
-    // Delegate the actual GeoJSON → File-Geodatabase → ZIP work to the
-    // internal tools service (biip-tools /gdb endpoint). Keeps GDAL out of
-    // this image.
-    const zipBuffer: Buffer = await ctx.call('tools.makeGdb', {
-      geojson,
-      name: `israsas-${request.id}`,
-      srid: 3346,
-    });
-
-    const folder = `uploads/requests/${
-      (request.tenant as Tenant)?.id || 'private'
-    }/${(request.createdBy as any as User)?.id || 'user'}`;
-
-    const stream = Readable.from(zipBuffer);
-
-    const result: any = await ctx.call(
-      'minio.uploadFile',
-      {
-        payload: stream,
-        folder,
-        isPrivate: true,
-        types: ['application/zip', 'application/x-zip-compressed'],
-        name: `israsas-${request.id}`,
-      },
-      {
-        meta: {
-          mimetype: 'application/zip',
-          filename: `israsas-${request.id}.zip`,
-        },
-      }
-    );
-
-    await ctx.call('requests.saveGeneratedPdf', { id, url: result.url });
-
-    return { generating: true };
+    return {
+      generating: !!flow?.job?.id,
+    };
   }
 
   @Action({

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -120,7 +120,7 @@ export default class ToolsService extends moleculer.Service {
   })
   async makeGdb(
     ctx: Context<{ geojson: any; name?: string; srid?: number }>
-  ): Promise<Buffer> {
+  ): Promise<NodeJS.ReadableStream> {
     const { geojson, name, srid } = ctx.params;
     const gdbEndpoint = `${this.toolsHost()}/gdb`;
 
@@ -141,8 +141,10 @@ export default class ToolsService extends moleculer.Service {
       );
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-    return Buffer.from(arrayBuffer);
+    // Stream the response body straight to the consumer (MinIO upload) so we
+    // never buffer the entire ZIP in memory — per-request RSS otherwise
+    // spikes proportional to the GDB archive size.
+    return toReadableStream(response.body?.getReader());
   }
 
   @Action({

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -112,6 +112,41 @@ export default class ToolsService extends moleculer.Service {
 
   @Action({
     params: {
+      geojson: 'object',
+      name: { type: 'string', optional: true },
+      srid: { type: 'number', optional: true, convert: true },
+    },
+    timeout: 0,
+  })
+  async makeGdb(
+    ctx: Context<{ geojson: any; name?: string; srid?: number }>
+  ): Promise<Buffer> {
+    const { geojson, name, srid } = ctx.params;
+    const gdbEndpoint = `${this.toolsHost()}/gdb`;
+
+    const response = await fetch(gdbEndpoint, {
+      method: 'POST',
+      body: JSON.stringify({
+        geojson,
+        srid: srid ?? 3346,
+        ...(name ? { name } : {}),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(
+        `tools /gdb returned ${response.status}: ${detail || '<empty body>'}`
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  @Action({
+    params: {
       url: 'string',
       name: 'string',
     },


### PR DESCRIPTION
## Summary

Adds per-request **Geodatabase (.zip)** extract format, the spatial counterpart to the existing basic / extended PDF flow. Stacked on top of #86 (the GeoJSON removal). When a user selects \"Erdviniai duomenys (Geodatabase)\" on \`/duomenu-gavimas\`, the request carries \`data.format = 'GDB'\` and on admin approval is fulfilled by generating an ESRI File Geodatabase containing only the selected objects' geometries.

Heavy lifting (GDAL / zip) lives in the shared internal services API — see companion **biip-tools#14**. This repo only assembles the per-request GeoJSON and uploads the returned ZIP to MinIO.

## Flow per request

1. User picks \"Erdviniai duomenys (Geodatabase)\" + selects cadastralIds (and optionally draws a polygon) on the request form
2. Admin approves → \`requests.updated\` event → \`generatePdfIfNeeded\` routes by \`data.format\`
3. \`generateGdb\` queries \`objects.find({ cadastralId: { \$in }, geom })\` for *only the selected objects*, flatMaps every object's geometry into Features, and POSTs the resulting FeatureCollection to \`TOOLS_HOST/gdb\`
4. biip-tools returns a ZIP (containing \`israsas-<id>.gdb/\`) which is uploaded to MinIO as \`israsas-<id>.zip\`
5. \`saveGeneratedPdf\` writes the URL back to \`request.generatedFile\` — same email + UI surfaces as PDF

Unlike the bulk \`opengis.lt/uetk_gdb.zip\` (all UETK data), this ZIP contains **only the user's selected objects**.

## Changes

| File | Change |
|---|---|
| \`services/tools.service.ts\` | New \`makeGdb\` action: POSTs GeoJSON to \`TOOLS_HOST/gdb\`, returns ZIP as Buffer; non-2xx → throw with response body |
| \`services/requests.service.ts\` | Restored \`RequestFormat\` (PDF \| GDB) const + \`data.format\` schema + interface; new \`generateGdb\` action; \`generatePdfIfNeeded\` routes \`format=GDB\` through \`generateGdb\` |

## Dependencies

- **biip-tools PR #14** — must deploy first; this PR's \`generateGdb\` action no-ops via the tools.makeGdb error path until \`/tools/gdb\` exists
- biip-uetk-web add-gdb-extract-format PR — adds the dropdown option
- biip-admin-web uetk/add-gdb-extract-format PR — adds the admin filter / table label

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After biip-tools deploys: \`curl -X POST http://localhost:3000/uetk/requests \` with \`{ data: { format: 'GDB' }, objects: [{type:'CADASTRAL_ID', id:12211142}], ... }\` → admin approve → check MinIO for \`israsas-<id>.zip\`, open in QGIS to confirm geometry matches the requested object
- [ ] Approving without \`format\` still generates PDF
- [ ] Approving a request whose only object has no geometry → \`{generating: false}\` (no upload, no orphan record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)