### PR TITLE
UETK extract: 1280x960 screenshot viewport from the PDF call site

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -140,7 +140,12 @@ export default class JobsRequestsService extends moleculer.Service {
     });
 
     const childrenJobs = data.map((item) => ({
-      params: { ...item, waitFor: '#image-canvas-0' },
+      // 1280x960 (4:3) gives the extract-PDF map ~50% of an A4-portrait page
+      // height instead of the ~29% the upstream biip-tools default (1280x720)
+      // landed on — see issue from stakeholder where the map and its labels
+      // were too small to read. Passed per-call so unrelated tools.makeScreenshot
+      // consumers keep the upstream default.
+      params: { ...item, waitFor: '#image-canvas-0', width: 1280, height: 960 },
       name: 'jobs',
       action: 'saveScreenshot',
     }));

--- a/services/jobs.service.ts
+++ b/services/jobs.service.ts
@@ -34,6 +34,16 @@ export default class JobsService extends moleculer.Service {
         type: 'string',
         optional: true,
       },
+      width: {
+        type: 'number',
+        optional: true,
+        convert: true,
+      },
+      height: {
+        type: 'number',
+        optional: true,
+        convert: true,
+      },
     },
     timeout: 0,
   })
@@ -43,9 +53,11 @@ export default class JobsService extends moleculer.Service {
       hash: string;
       waitFor: string;
       data: { [key: string]: any };
+      width?: number;
+      height?: number;
     }>
   ) {
-    const { url, hash, data, waitFor } = ctx.params;
+    const { url, hash, data, waitFor, width, height } = ctx.params;
     const { job } = ctx.locals;
 
     const folder = 'temp/screenshots';
@@ -76,6 +88,8 @@ export default class JobsService extends moleculer.Service {
       url,
       waitFor,
       stream: true,
+      ...(typeof width === 'number' ? { width } : {}),
+      ...(typeof height === 'number' ? { height } : {}),
     });
 
     await ctx.call(

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -25,6 +25,16 @@ export default class ToolsService extends moleculer.Service {
         type: 'string',
         optional: true,
       },
+      width: {
+        type: 'number',
+        convert: true,
+        optional: true,
+      },
+      height: {
+        type: 'number',
+        convert: true,
+        optional: true,
+      },
     },
     timeout: 0,
   })
@@ -34,15 +44,24 @@ export default class ToolsService extends moleculer.Service {
       stream: boolean;
       encoding: string;
       waitFor: string;
+      width?: number;
+      height?: number;
     }>
   ) {
-    const { url, stream, encoding, waitFor } = ctx.params;
+    const { url, stream, encoding, waitFor, width, height } = ctx.params;
     const searchParams = new URLSearchParams({
       quality: '75',
       url: url,
       type: 'jpeg',
       encoding,
     });
+
+    // Only override the upstream biip-tools default viewport (1280x720) when
+    // the caller explicitly asks. The extract-PDF flow passes its own larger
+    // dimensions from jobs.requests.initiatePdfGenerate; everything else gets
+    // the unchanged default.
+    if (typeof width === 'number') searchParams.set('width', String(width));
+    if (typeof height === 'number') searchParams.set('height', String(height));
 
     if (waitFor) {
       searchParams.set('waitFor', waitFor);


### PR DESCRIPTION
## Summary

Companion to biip-maps-web's \`extract-map-improvements\` PR. The stakeholder reported the extract PDF map was too small (~520×293 in A4 portrait, under 30% of content height) to read the marked object's kadastro_id label at QGIS's scale-dependent label thresholds.

Bump the puppeteer viewport biip-tools renders into so the embedded JPEG scales to ~520×390 (~50% of A4 portrait content height) without changing the PDF layout.

## Changes

- \`services/tools.service.ts\` — accept \`width\` / \`height\` as optional \`makeScreenshot\` params and pass them through to biip-tools \`/screenshot\` ONLY when the caller provides them. Defaults stay at the upstream biip-tools values (1280×720) so unrelated callers aren't silently widened.
- \`services/jobs.service.ts\` — accept \`width\` / \`height\` on the \`saveScreenshot\` queued job; forward to \`tools.makeScreenshot\`.
- \`services/jobs.requests.service.ts\` — pass \`width: 1280, height: 960\` from \`initiatePdfGenerate\`'s children, scoping the bump to the extract-PDF flow only.

## Companion PRs

- biip-maps-web \`extract-map-improvements\` — column legend + colons + basin sublayers + maxZoom=8 for surrounding context

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: trigger a fresh GDB / PDF extract request → screenshot is 1280×960 (~50% of A4 content height) → kadastro_id label visible
- [ ] Existing \`tools.makeScreenshot\` callers without width/height continue to get 1280×720

🤖 Generated with [Claude Code](https://claude.com/claude-code)