### PR TITLE
extract PDF: landscape A4 + 1280x800 viewport

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -76,6 +76,12 @@ export default class JobsRequestsService extends moleculer.Service {
     const pdf = await ctx.call('tools.makePdf', {
       url: `${process.env.SERVER_HOST}/jobs/requests/${id}/html?secret=${secret}&skey=${screenshotsHash}`,
       footer: footerHtml,
+      // Landscape A4 — the embedded map screenshot then renders at
+      // ~777x583 (~75% of content area) instead of ~520x390 in portrait,
+      // letting the QGIS scale-dependent label for the marked object
+      // (name + kadastro_id) actually render. Stakeholder OK'd this as
+      // the fallback if portrait + bigger viewport wasn't enough.
+      landscape: true,
     });
 
     const folder = this.getFolderName(
@@ -140,12 +146,11 @@ export default class JobsRequestsService extends moleculer.Service {
     });
 
     const childrenJobs = data.map((item) => ({
-      // 1280x960 (4:3) gives the extract-PDF map ~50% of an A4-portrait page
-      // height instead of the ~29% the upstream biip-tools default (1280x720)
-      // landed on — see issue from stakeholder where the map and its labels
-      // were too small to read. Passed per-call so unrelated tools.makeScreenshot
-      // consumers keep the upstream default.
-      params: { ...item, waitFor: '#image-canvas-0', width: 1280, height: 960 },
+      // 1280x800 (16:10) — fits landscape A4 content area (742x495pt at 50pt
+      // margins) at ~94% utilization (742x464pt rendered). Going taller risks
+      // overflow into the bottom margin; the previous 1280x960 was sized for
+      // portrait and overflows by ~60pt in landscape.
+      params: { ...item, waitFor: '#image-canvas-0', width: 1280, height: 800 },
       name: 'jobs',
       action: 'saveScreenshot',
     }));

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -90,13 +90,23 @@ export default class ToolsService extends moleculer.Service {
         type: 'string',
         optional: true,
       },
+      landscape: {
+        type: 'boolean',
+        optional: true,
+        convert: true,
+      },
     },
     timeout: 0,
   })
   async makePdf(
-    ctx: Context<{ url: string; header?: string; footer?: string }>
+    ctx: Context<{
+      url: string;
+      header?: string;
+      footer?: string;
+      landscape?: boolean;
+    }>
   ) {
-    const { url, footer, header } = ctx.params;
+    const { url, footer, header, landscape } = ctx.params;
 
     const pdfEndpoint = `${this.toolsHost()}/pdf`;
 
@@ -109,6 +119,7 @@ export default class ToolsService extends moleculer.Service {
           width: 620,
           footer,
           header,
+          ...(typeof landscape === 'boolean' ? { landscape } : {}),
           margin: {
             top: 50,
             bottom: 50,


### PR DESCRIPTION
## Summary

Stacked on top of #88 (extract-map-bigger-screenshot). The stakeholder offered landscape as the fallback if portrait + bigger viewport wasn't enough for QGIS's scale-dependent labels (object name + kadastro_id on the map) to render. Going with landscape.

Math:
- A4 portrait content area (50pt margins): 495 × 742 pt
- A4 landscape content area (50pt margins): 742 × 495 pt
- Embedded screenshot at \`<img class=\"w-full\">\` scales to content-area width
- Old portrait + 1280×720: ~520 × 293 pt (29% of A4 content height)
- New landscape + 1280×800: ~742 × 464 pt (94% of A4 content height = ~75% of total page)

## Changes

- \`services/tools.service.ts\` — \`makePdf\` accepts \`landscape\` boolean param; forwards to biip-tools (where it lands on puppeteer's \`pdf.landscape\`). Optional / spread-only when set, so callers that don't care get unchanged portrait.
- \`services/jobs.requests.service.ts\`:
  - \`tools.makePdf\` call: \`landscape: true\` for extract PDFs
  - \`saveScreenshot\` child jobs: viewport changed \`1280×960\` → \`1280×800\` (16:10) to fit landscape A4 at ~94%. The 1280×960 from #88 was sized for portrait and would overflow the landscape content height by ~60pt.

## Companion PRs

- biip-tools \`pdf-landscape-option\` — adds the \`landscape\` param to the shared /pdf service
- Stacks on top of biip-uetk-api #88 (extract-map-bigger-screenshot)

## Deployment ordering

1. biip-tools landscape PR (must deploy first — without it, the \`landscape\` param this PR sends gets silently ignored)
2. This PR
3. Optional: biip-uetk-api #88 doesn't have to land — this PR overrides its 1280×960 anyway

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After biip-tools landscape lands + this PR's deploy: trigger extract approval → PDF arrives in landscape A4 with map ~742×464pt → marked object's kadastro_id label readable
- [ ] Map page doesn't overflow into the bottom margin
- [ ] Cover-page tables / object data still render correctly on landscape pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)