### PR TITLE
extract: restore GeoJSON format (reprojected to WGS84 via tools.reproject)

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -219,6 +219,131 @@ export default class JobsRequestsService extends moleculer.Service {
   }
 
   @Action({
+    queue: true,
+    params: {
+      id: 'number',
+    },
+    timeout: 0,
+  })
+  async generateAndSaveGeoJson(ctx: Context<{ id: number }>) {
+    const { id } = ctx.params;
+
+    const request: Request = await ctx.call('requests.resolve', {
+      id,
+      populate: 'createdBy,tenant,geom',
+    });
+
+    if (!request?.id) return { skipped: 'no-request' };
+
+    const cadastralIds = request.objects
+      ?.filter((i) => i.type === 'CADASTRAL_ID')
+      ?.map((i) => i.id)
+      ?.filter((i) => !!i);
+
+    const query: any = {};
+    if (cadastralIds?.length) query.cadastralId = { $in: cadastralIds };
+    if (request.geom && Object.keys(request.geom).length) query.geom = request.geom;
+
+    if (!query.cadastralId && !query.geom) return { skipped: 'no-objects' };
+
+    const objects: UETKObject[] = await ctx.call('objects.find', {
+      query,
+      populate: 'geom',
+    });
+
+    // Same feature assembly as generateAndSaveGdb so a user requesting
+    // both formats gets the same attribute table either way. Kept
+    // duplicated rather than factored out because the GDB path will
+    // diverge once it switches to multi-layer / category-bucketed
+    // output (PR #91); GeoJSON stays a single FeatureCollection.
+    const features = objects.flatMap((obj: any) => {
+      const baseProps = {
+        cadastralId: obj.cadastralId,
+        name: obj.name,
+        category: obj.category,
+        categoryTranslate: obj.categoryTranslate,
+        municipality: obj.municipality,
+        municipalityCode: obj.municipalityCode,
+        area: obj.area,
+        length: obj.length,
+      };
+      if (
+        obj.geom?.type === 'FeatureCollection' &&
+        Array.isArray(obj.geom.features)
+      ) {
+        return obj.geom.features
+          .filter((f: any) => f?.geometry?.type)
+          .map((f: any) => ({
+            type: 'Feature',
+            geometry: f.geometry,
+            properties: { ...baseProps, ...(f.properties || {}) },
+          }));
+      }
+      const geometry =
+        obj.geom?.geometry || (obj.geom?.type ? obj.geom : null);
+      if (!geometry?.type) return [];
+      return [{ type: 'Feature', geometry, properties: baseProps }];
+    });
+
+    if (!features.length) return { skipped: 'no-geometries' };
+
+    const geojson = { type: 'FeatureCollection', features };
+
+    // Publishing.uetkMerged stores geometries in EPSG:3346 (LKS-94), but
+    // the GeoJSON spec mandates WGS84 (EPSG:4326). A raw 3346 GeoJSON
+    // does not load in QGIS or any web map tool without a manual CRS
+    // hint — which the stakeholder confirmed as the blocker that killed
+    // the previous GeoJSON output. tools.reproject pipes through
+    // ogr2ogr -s_srs 3346 -t_srs 4326 and streams the result back.
+    // A failure here MUST rethrow so BullMQ marks the job failed and
+    // the request doesn't end up APPROVED with a missing file.
+    const stream: NodeJS.ReadableStream = await ctx
+      .call('tools.reproject', {
+        geojson,
+        sourceSrid: 3346,
+        targetSrid: 4326,
+      })
+      .then((s) => s as NodeJS.ReadableStream)
+      .catch((err: any) => {
+        this.logger.error(
+          `tools.reproject failed for request ${request.id} ` +
+            `(${features.length} features)`,
+          err,
+        );
+        throw err;
+      });
+
+    const folder = this.getFolderName(
+      request?.createdBy as any as User,
+      request?.tenant as Tenant
+    );
+
+    const result: any = await ctx.call(
+      'minio.uploadFile',
+      {
+        payload: stream,
+        folder,
+        isPrivate: true,
+        // Browsers / curl uploads can present either of these for a
+        // .geojson, depending on the OS mime table. MinIO matches against
+        // this list, so accept both.
+        types: ['application/geo+json', 'application/json'],
+        name: `israsas-${request.id}`,
+      },
+      {
+        meta: {
+          mimetype: 'application/geo+json',
+          filename: `israsas-${request.id}.geojson`,
+        },
+      }
+    );
+
+    await ctx.call('requests.saveGeneratedPdf', { id, url: result.url });
+
+    return { generated: true };
+  }
+
+  @Action({
     params: {
       id: 'number',
     },
@@ -229,6 +354,22 @@ export default class JobsRequestsService extends moleculer.Service {
     // BullMQ retry semantics inherited from the mixin (5 attempts, 1s
     // backoff). Mirrors initiatePdfGenerate but without the flow() step.
     const job = await this.localQueue(ctx, 'generateAndSaveGdb', {
+      id: ctx.params.id,
+    });
+    return { job: { id: job.id } };
+  }
+
+  @Action({
+    params: {
+      id: 'number',
+    },
+    timeout: 0,
+  })
+  async initiateGeoJsonGenerate(ctx: Context<{ id: number }>) {
+    // Same shape as initiateGdbGenerate — single queued job, BullMQ
+    // retry semantics inherited from the mixin. No screenshot children
+    // since GeoJSON is a pure data extract.
+    const job = await this.localQueue(ctx, 'generateAndSaveGeoJson', {
       id: ctx.params.id,
     });
     return { job: { id: job.id } };

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -75,6 +75,7 @@ export const PurposeTypes = {
 export const RequestFormat = {
   PDF: 'PDF',
   GDB: 'GDB',
+  GEOJSON: 'GEOJSON',
 };
 
 const VISIBLE_TO_USER_SCOPE = 'visibleToUser';
@@ -453,6 +454,27 @@ export default class RequestsService extends moleculer.Service {
 
   @Action({
     params: {
+      id: { type: 'number', convert: true },
+    },
+    rest: 'POST /:id/generate-geojson',
+    timeout: 0,
+  })
+  async generateGeoJson(ctx: Context<{ id: number }>) {
+    // Same shape as generateGdb — delegate to a BullMQ job so the tools
+    // call (reproject 3346 → 4326) + MinIO upload can retry on transient
+    // failures and so a 5xx from tools doesn't leave the request stuck
+    // in APPROVED without a generatedFile.
+    const flow: any = await ctx.call('jobs.requests.initiateGeoJsonGenerate', {
+      id: ctx.params.id,
+    });
+
+    return {
+      generating: !!flow?.job?.id,
+    };
+  }
+
+  @Action({
+    params: {
       id: {
         type: 'number',
         convert: true,
@@ -653,6 +675,8 @@ export default class RequestsService extends moleculer.Service {
 
     if (request.data?.format === RequestFormat.GDB) {
       this.broker.call('requests.generateGdb', { id: request.id });
+    } else if (request.data?.format === RequestFormat.GEOJSON) {
+      this.broker.call('requests.generateGeoJson', { id: request.id });
     } else {
       this.broker.call('requests.generatePdf', { id: request.id });
     }

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -179,6 +179,49 @@ export default class ToolsService extends moleculer.Service {
 
   @Action({
     params: {
+      geojson: 'object',
+      sourceSrid: { type: 'number', optional: true, convert: true },
+      targetSrid: { type: 'number', optional: true, convert: true },
+    },
+    timeout: 0,
+  })
+  async reproject(
+    ctx: Context<{
+      geojson: any;
+      sourceSrid?: number;
+      targetSrid?: number;
+    }>,
+  ): Promise<NodeJS.ReadableStream> {
+    const { geojson, sourceSrid, targetSrid } = ctx.params;
+    const reprojectEndpoint = `${this.toolsHost()}/reproject`;
+
+    const response = await fetch(reprojectEndpoint, {
+      method: 'POST',
+      body: JSON.stringify({
+        geojson,
+        sourceSrid: sourceSrid ?? 3346,
+        targetSrid: targetSrid ?? 4326,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(
+        `tools /reproject returned ${response.status}: ${
+          detail || '<empty body>'
+        }`,
+      );
+    }
+
+    // Same streaming pattern as makeGdb — the reprojected GeoJSON can be
+    // multi-MB for a large request; piping straight to MinIO avoids
+    // buffering the whole payload twice.
+    return toReadableStream(response.body?.getReader());
+  }
+
+  @Action({
+    params: {
       url: 'string',
       name: 'string',
     },


### PR DESCRIPTION
PR #86 (`2acc15b`) ripped out GeoJSON as an extract format because the file wouldn't open in QGIS. The stakeholder follow-up confirmed the root cause: `publishing.uetkMerged` is EPSG:3346 (LKS-94), the GeoJSON spec mandates WGS84 (EPSG:4326), and QGIS refuses to load a 3346 GeoJSON without a manual CRS hint. They showed a 'fixed' file where they had hand-edited a CRS member in — proves the format itself is fine, only the projection blocked them.

Restore GeoJSON as a first-class output, with the 3346→4326 reprojection done on the server so users never have to touch CRS.

## Pieces

- **`requests.service.ts`** — `RequestFormat.GEOJSON` enum value restored; `generateGeoJson` REST action mirroring `generateGdb` (delegates to a BullMQ job); `generatePdfIfNeeded()` routes `format='GEOJSON'` to the new action alongside the existing PDF/GDB branches.

- **`tools.service.ts`** — `tools.reproject` action wrapping the upstream `/reproject` endpoint added in [biip-tools PR #18](https://github.com/AplinkosMinisterija/biip-tools/pull/18). Same streaming shape as `makeGdb` so the caller pipes straight to MinIO without buffering multi-MB payloads.

- **`jobs.requests.service.ts`** — `initiateGeoJsonGenerate` + queued `generateAndSaveGeoJson`. Feature assembly intentionally duplicated from `generateAndSaveGdb` rather than factored out — the GDB path is about to diverge into multi-layer / category-bucketed output via [PR #91](https://github.com/AplinkosMinisterija/biip-uetk-api/pull/91), while GeoJSON stays a single FeatureCollection. `reproject` failure rethrows so BullMQ marks the job failed instead of leaving the request APPROVED with no `generatedFile`.

## Dependencies

- **Requires [biip-tools PR #18](https://github.com/AplinkosMinisterija/biip-tools/pull/18)** deployed to the same environment for `/reproject` to exist.
- **Branches off main, not PR #91.** After #91 merges, `generateAndSaveGeoJson` baseProps will need a follow-up rebase to use the new published schema (`kadastro_id` / `pavadinimas` / ...). Filed as a known follow-up rather than blocking either PR on the other.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: create a request, set `data.format = 'GEOJSON'`, approve → `generatedFile` resolves to an `israsas-<id>.geojson` on MinIO
- [ ] Downloaded file opens in QGIS **without a CRS prompt** — coordinates fall inside lat/lng ranges (`-180≤lng≤180, -90≤lat≤90`)
- [ ] Mixed-geometry request (point + line + polygon objects) → all features land in the single FeatureCollection, none dropped
- [ ] Force a `tools` failure (point `TOOLS_HOST` at unreachable endpoint) → request stays observably broken (BullMQ job fails) instead of silently APPROVED-with-no-file
- [ ] PDF and GDB paths unaffected — same request without `format` still goes to PDF, `format='GDB'` still goes to GDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)