### PR TITLE
extract GeoJSON: align baseProps with hotfix #93

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -330,11 +330,9 @@ export default class JobsRequestsService extends moleculer.Service {
         kadastro_id: obj.cadastralId,
         pavadinimas: obj.name,
         kategorija: obj.categoryTranslate,
-        registracijos_data: obj.registrationDate,
-        upiu_pabas_id: obj.subbasinId,
-        objekto_x: obj.centroidX,
-        objekto_y: obj.centroidY,
-        st_area: obj.stArea,
+        objekto_x: obj.lng,
+        objekto_y: obj.lat,
+        st_area: obj.area,
       };
       if (
         obj.geom?.type === 'FeatureCollection' &&


### PR DESCRIPTION
Companion to [#93](https://github.com/AplinkosMinisterija/biip-uetk-api/pull/93). The GDB job's baseProps were hotfixed to drop `obj.registrationDate` / `obj.subbasinId` / `obj.centroidX` / `obj.centroidY` / `obj.stArea` (5 UETKObject fields wired to nonexistent `publishing.uetkMerged` columns — knex would have thrown at query time). `generateAndSaveGeoJson` (landed on main via `464cf8d`) has the same wiring and the same crash potential — fix it the same way.

Output column shape unchanged: `id / kadastro_id / pavadinimas / kategorija / objekto_x / objekto_y / st_area`. Sources mirror the GDB job after #93:
- `objekto_x` / `objekto_y` = `obj.lng` / `obj.lat` (WGS84, not LKS-94)
- `st_area` = `obj.area`
- `registracijos_data` + `upiu_pabas_id` drop entirely (no source column)

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: GeoJSON format request lands a `.geojson` file on MinIO (no knex "column doesn't exist" errors)
- [ ] Output GeoJSON loads in QGIS without a CRS prompt (4326 reprojection from tools.reproject already in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)