### PR TITLE
extract GDB: show LT layer names in QGIS (Upės / Ežerai_ir_tvenkiniai / Hidrotechniniai_statiniai)

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -19,6 +19,18 @@ import { Request } from './requests.service';
 import { Tenant } from './tenants.service';
 import { User } from './users.service';
 
+// Layer names shown to the QGIS / ArcGIS user when opening the extract
+// .gdb. Keyed by geometry family because every UETKObjectType maps
+// 1:1 to a family (rivers/canals -> lines, lakes/ponds -> polygons,
+// dams/hydro/fish/culvert -> points). OpenFileGDB launders whitespace
+// to underscores, so the LT names are written with underscores
+// upfront — the GDB file ends up with the exact name we send.
+const GDB_LAYER_NAMES = {
+  lines: 'Upės',
+  polygons: 'Ežerai_ir_tvenkiniai',
+  points: 'Hidrotechniniai_statiniai',
+} as const;
+
 @Service({
   name: 'jobs.requests',
   mixins: [BullMqMixin],
@@ -198,15 +210,15 @@ export default class JobsRequestsService extends moleculer.Service {
       >
     )
       .filter(([, items]) => items.length > 0)
-      .map(([name, items]) => ({
-        name,
+      .map(([family, items]) => ({
+        name: GDB_LAYER_NAMES[family],
         geojson: {
           type: 'FeatureCollection',
           features: items.map(({ geometry, obj, inheritedProps }) => ({
             type: 'Feature',
             geometry,
             properties: {
-              ...this.basePropsForFamily(obj, name),
+              ...this.basePropsForFamily(obj, family),
               ...inheritedProps,
             },
           })),


### PR DESCRIPTION
Stakeholder feedback after the per-family schema landed: QGIS shows the three layers with snake_case engine names (`points`/`lines`/`polygons`), should show user-friendly LT labels:

| Family (internal) | Public GDB layer (now) |
|---|---|
| `lines` | **Upės** (RIVER + CANAL) |
| `polygons` | **Ežerai_ir_tvenkiniai** (all 6 lake/pond subtypes) |
| `points` | **Hidrotechniniai_statiniai** (HYDRO + FISH_PASS + EARTH_DAM + WATER_EXCESS_CULVERT) |

## Implementation

A module-level `GDB_LAYER_NAMES` map keyed on the family. The bucket keys (`points`/`lines`/`polygons`) stay as-is so `basePropsForFamily` reads the geometry semantics naturally; only the OUTPUT layer name is translated.

## Underscores vs spaces

OpenFileGDB launders spaces to underscores at write time (driver constraint), so I spell the names with underscores upfront — the resulting `.gdb` bytes match what we send, and QGIS shows `Ežerai_ir_tvenkiniai` deterministically. Alternative would be an XSD wrapper to keep spaces verbatim, but that's a separate piece of work (also needed for field aliases — stakeholder follow-up).

## Dependency

Requires [biip-tools PR #20](https://github.com/AplinkosMinisterija/biip-tools/pull/20) deployed for the `/gdb` endpoint's layer-name validator to accept LT diacritics (`ąčęėįšųūž`). Without it, `Ežerai_ir_tvenkiniai` fails validation with 400.

The single-layer path (used when the extract has only one geometry family) is unaffected — it passes the archive name, not a layer name.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: extract for a mixed-geometry request produces a `.gdb` whose QGIS Layers panel shows `Upės`, `Ežerai_ir_tvenkiniai`, `Hidrotechniniai_statiniai` (not `points`/`lines`/`polygons`)
- [ ] Single-geometry extracts unchanged
- [ ] Field aliases (`kadastro_id` → 'Identifikavimo kodas') deferred to a separate follow-up PR per stakeholder triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)