### PR TITLE
extract GDB: always use layers payload (single-family extracts also get LT layer names)

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -228,25 +228,22 @@ export default class JobsRequestsService extends moleculer.Service {
 
     const archiveName = `israsas-${request.id}`;
     // tools.makeGdb streams the ZIP back as a Node Readable (no buffering).
-    // A failure here MUST surface — historically the BullMQ retry loop ate
-    // the rejection and the request stayed APPROVED with no generated file
-    // (BĮIP request Nr. 232). We rethrow so BullMQ marks the job failed
-    // *and* the request stays observably broken instead of silently green.
+    // Always use the `layers` payload (even for single-family requests)
+    // so the layer-name inside the .gdb is the LT label from
+    // GDB_LAYER_NAMES, not the archive name. The single-geojson legacy
+    // shape would name the layer `israsas-${id}` instead.
+    //
+    // A failure here MUST surface — historically the BullMQ retry loop
+    // ate the rejection and the request stayed APPROVED with no
+    // generated file (BĮIP request Nr. 232). We rethrow so BullMQ marks
+    // the job failed *and* the request stays observably broken instead
+    // of silently green.
     const stream: NodeJS.ReadableStream = await ctx
-      .call(
-        'tools.makeGdb',
-        populatedLayers.length === 1
-          ? {
-              geojson: populatedLayers[0].geojson,
-              name: archiveName,
-              srid: 3346,
-            }
-          : {
-              layers: populatedLayers,
-              name: archiveName,
-              srid: 3346,
-            },
-      )
+      .call('tools.makeGdb', {
+        layers: populatedLayers,
+        name: archiveName,
+        srid: 3346,
+      })
       .then((s) => s as NodeJS.ReadableStream)
       .catch((err: any) => {
         this.logger.error(


### PR DESCRIPTION
Follow-up on [#98](https://github.com/AplinkosMinisterija/biip-uetk-api/pull/98). PR #98 added `GDB_LAYER_NAMES` and the LT layer naming, but missed one branch:

When the request had **only one geometry family** (e.g. river-only or lake-only), the call site fell through to the legacy single-layer payload:

```ts
populatedLayers.length === 1
  ? { geojson: populatedLayers[0].geojson, name: archiveName }  // ← inner layer named after archive (`israsas-N`)
  : { layers: populatedLayers, name: archiveName }              // ← LT name
```

biip-tools `/gdb` defaults the layer name to the archive name when no `layers[].name` is provided, so a river-only extract opened in QGIS as `israsas-N` instead of `Upės`.

## Fix

Drop the branch — always send the `layers[]` payload, even when there's one family. biip-tools `/gdb` already handles a 1-element `layers` array. Now QGIS shows `Upės` / `Ežerai_ir_tvenkiniai` / `Hidrotechniniai_statiniai` regardless of whether the request spans one family or all three.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: river-only extract → QGIS shows the layer as `Upės` (not `israsas-N`)
- [ ] Lake-only extract → `Ežerai_ir_tvenkiniai`
- [ ] Mixed extract still shows the right three layers (no regression from #98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)