### PR TITLE
extract PDF map: use PNG screenshot (lossless) instead of JPEG q=75

### DIFF
--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -49,10 +49,16 @@ export default class ToolsService extends moleculer.Service {
     }>
   ) {
     const { url, stream, encoding, waitFor, width, height } = ctx.params;
+    // PNG (lossless) instead of JPEG q=75: the extract-PDF map page
+    // was showing JPEG compression artifacts on label text and basin
+    // outlines, which a 1280x1400 screenshot downscaled into ~495x542pt
+    // of the PDF only amplified. PNG roughly doubles the screenshot
+    // payload size but the PDF embedder still re-compresses on the
+    // final page, so the on-disk PDF grows modestly while the rendered
+    // map reads as crisp as the live screenshot in the browser.
     const searchParams = new URLSearchParams({
-      quality: '75',
       url: url,
-      type: 'jpeg',
+      type: 'png',
       encoding,
     });
 


### PR DESCRIPTION
Stakeholder feedback comparing the live browser session at `/uetk?screenshot=1` vs the rendered extract PDF map page: live = crisp, PDF = JPEG-noisy on label text + stroke edges.

## Root cause

`services/tools.service.ts` `makeScreenshot` hardcodes:

```ts
quality: '75',
type: 'jpeg',
```

The puppeteer screenshot is JPEG q=75 (1280×1400), which the PDF then downscales to ~495×542pt on the map page. JPEG noise survives both compressions and reads as soft / smudgy where the live browser session looks crisp (browser renders the map natively, PNG-quality).

## Change

Switch `type` to `png` (lossless). Drop `quality` (JPEG-only). One file, four lines.

biip-tools `/screenshot` endpoint already supports `type=png` (OpenAPI lists `image/png` alongside `image/jpeg`), no upstream change needed.

## Cost

PNG payload from puppeteer is bigger (rough estimate: 2-4× the JPEG q=75 bytes for a map screenshot — couple hundred KB to ~1MB depending on detail). The PDF embedder re-compresses on the final page, so the user-visible `israsas-N.pdf` grows modestly, not by the full PNG/JPEG ratio.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: regenerate an extract PDF — map page reads crisp (basin labels, stroke edges, ežerai labels match what `/uetk?screenshot=1` shows in the browser)
- [ ] PDF file size hasn't ballooned unreasonably (compare 1-2 sample extracts before/after)
- [ ] No other regression (PDF render time, MinIO upload size budget, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)