### PR TITLE
extract PDF: label river name + drop downstream-receiver line

### DIFF
--- a/templates/request.ejs
+++ b/templates/request.ejs
@@ -158,16 +158,9 @@
           <hr />
           <% if (['RIVER', 'CANAL'].includes(item.category)) { %>
             <div class="flex flex-col items-center my-4">
-              <p class="font-bold text-xl"><%= item.extendedData?.pavadinimas || item.name || '' %></p>
+              <p>Kadastro objekto pavadinimas: <b><%= item.extendedData?.pavadinimas || item.name || '' %></b></p>
               <% if (item.extendedData?.kadastroId || item.cadastralId) { %>
                 <p>Identifikavimo kodas: <b><%= item.extendedData?.kadastroId || item.cadastralId %></b></p>
-              <% } %>
-              <% var downstream = [
-                   ...(item.extendedData?.vyrUpes || []),
-                   ...(item.extendedData?.vyrEzeraiTvenkiniai || [])
-                 ].find(function(r) { return r && (r.pavadinimas || r.kodas); }); %>
-              <% if (downstream) { %>
-                <p class="mt-2">Vandens telkinys, į kurį įteka: <b><%= downstream.pavadinimas || '-' %></b><% if (downstream.kategorija) { %> (<%= downstream.kategorija.toLowerCase() %>)<% } %><% if (downstream.kodas) { %>, kodas <b><%= downstream.kodas %></b><% } %></p>
               <% } %>
             </div>
           <% } %>


### PR DESCRIPTION
## Summary
- Replace the bare bold river name at the top of each per-object PDF page with a labelled \`Kadastro objekto pavadinimas: <name>\` line so the reader sees what the value refers to.
- Drop the \`Vandens telkinys, į kurį įteka\` downstream-receiver line — stakeholder feedback flagged it as noise.

## Test plan
- [ ] Generate a request extract for a RIVER/CANAL object (e.g. cadastralId=12110006 / Novena) → PDF shows \`Kadastro objekto pavadinimas: Novena\`, \`Identifikavimo kodas: 12110006\`, no downstream-receiver line.
- [ ] Header is plain weight (label) + bold value; no red text, no XL size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)