### PR TITLE
extract screenshot: wait for legend ready flag, not map canvas

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -534,7 +534,19 @@ export default class JobsRequestsService extends moleculer.Service {
       // ŽEMĖLAPIO IŠTRAUKA title + numeris + data + object name block
       // (~190pt). Going taller (e.g. 1280x1600) would render under the
       // page bottom margin.
-      params: { ...item, waitFor: '#image-canvas-0', width: 1280, height: 1400 },
+      // Wait for the legend ready flag, not just the map canvas: biip-maps-web
+      // mounts <UiMapLegend> after the map fit completes and sets
+      // body[data-legend-ready="true"] when the async GetLegendGraphic fetch
+      // resolves (success OR failure). The previous '#image-canvas-0' selector
+      // matched as soon as OpenLayers attached its canvas, well before the
+      // legend HTTP round-trip, so the screenshot captured a half-rendered
+      // "Sutartiniai ženklai" section with no symbols.
+      params: {
+        ...item,
+        waitFor: 'body[data-legend-ready="true"]',
+        width: 1280,
+        height: 1400,
+      },
       name: 'jobs',
       action: 'saveScreenshot',
     }));


### PR DESCRIPTION
## Summary
- Switch the puppeteer `waitFor` selector from `#image-canvas-0` to `body[data-legend-ready="true"]` so the extract-PDF screenshot only fires after the asynchronous `GetLegendGraphic` round-trip resolves.
- Fixes the "Sutartiniai ženklai" block rendering as a single empty bullet in the captured PDF map page (legend symbols never had time to load).

## Why
- biip-maps-web's `<UiMapLegend>` toggles `body[data-legend-ready="true"]` in a `.finally()` after the legend fetch (success OR failure).
- The legend component only mounts after the map fit completes, so this flag implies both the map and the legend have settled.
- The previous `#image-canvas-0` selector matched as soon as OpenLayers attached its canvas, well before the legend HTTP request finished.

## Test plan
- [ ] Submit a request extract for a RIVER object (e.g. cadastralId=12110006 / Novena) → PDF map page shows fully rendered "Sutartiniai ženklai" with all legend symbols, not a single empty bullet.
- [ ] If the legend fetch fails for some reason, the screenshot still fires (the `.finally()` sets the flag either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)