### PR TITLE
extract PDF: revert PNG screenshot + legend-ready waitFor, use JPEG q=100

### DIFF
--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -534,19 +534,7 @@ export default class JobsRequestsService extends moleculer.Service {
       // ŽEMĖLAPIO IŠTRAUKA title + numeris + data + object name block
       // (~190pt). Going taller (e.g. 1280x1600) would render under the
       // page bottom margin.
-      // Wait for the legend ready flag, not just the map canvas: biip-maps-web
-      // mounts <UiMapLegend> after the map fit completes and sets
-      // body[data-legend-ready="true"] when the async GetLegendGraphic fetch
-      // resolves (success OR failure). The previous '#image-canvas-0' selector
-      // matched as soon as OpenLayers attached its canvas, well before the
-      // legend HTTP round-trip, so the screenshot captured a half-rendered
-      // "Sutartiniai ženklai" section with no symbols.
-      params: {
-        ...item,
-        waitFor: 'body[data-legend-ready="true"]',
-        width: 1280,
-        height: 1400,
-      },
+      params: { ...item, waitFor: '#image-canvas-0', width: 1280, height: 1400 },
       name: 'jobs',
       action: 'saveScreenshot',
     }));

--- a/services/tools.service.ts
+++ b/services/tools.service.ts
@@ -49,16 +49,15 @@ export default class ToolsService extends moleculer.Service {
     }>
   ) {
     const { url, stream, encoding, waitFor, width, height } = ctx.params;
-    // PNG (lossless) instead of JPEG q=75: the extract-PDF map page
-    // was showing JPEG compression artifacts on label text and basin
-    // outlines, which a 1280x1400 screenshot downscaled into ~495x542pt
-    // of the PDF only amplified. PNG roughly doubles the screenshot
-    // payload size but the PDF embedder still re-compresses on the
-    // final page, so the on-disk PDF grows modestly while the rendered
-    // map reads as crisp as the live screenshot in the browser.
+    // High-quality JPEG (q=100): PNG was tried to avoid q=75 compression
+    // artifacts on label text and basin outlines but broke extract
+    // generation downstream. q=100 keeps the file shape JPEG (what the
+    // PDF pipeline expects) while removing nearly all visible
+    // compression noise at the source resolution we ship.
     const searchParams = new URLSearchParams({
       url: url,
-      type: 'png',
+      type: 'jpeg',
+      quality: '100',
       encoding,
     });
 


### PR DESCRIPTION
## Why
PR #102 (PNG screenshot) and PR #104 (\`body[data-legend-ready="true"]\` waitFor) together broke extract generation in staging — \`nesigeneruoja\` per stakeholder. Hotfix rolls back both to the previously-shipping shape.

## Summary
- \`tools.service.ts\`: \`type='png'\` → \`type='jpeg'\` + new \`quality='100'\`
- \`jobs.requests.service.ts\`: \`waitFor: 'body[data-legend-ready="true"]'\` → \`waitFor: '#image-canvas-0'\` (the value before PR #104)

## Quality trade-off
- JPEG q=100 is what motivated the PNG switch (artifacts on labels at q=75). q=100 removes nearly all visible compression noise at the source resolution we ship; this is the conservative reintroduction.
- Legend may still capture half-rendered (the bug PR #104 tried to fix). Will revisit separately — needs verification that \`body[data-legend-ready]\` isn't what broke the screenshot pipeline before re-applying.

## Test plan
- [ ] Submit a request extract for a RIVER object (e.g. Novena / cadastralId=12110006) on staging → PDF generates without error.
- [ ] Map page label text is crisper than the prior q=75 PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)