### PR TITLE
extract PDF: restore text-xl on Kadastro objekto pavadinimas line

### DIFF
--- a/templates/request.ejs
+++ b/templates/request.ejs
@@ -158,7 +158,7 @@
           <hr />
           <% if (['RIVER', 'CANAL'].includes(item.category)) { %>
             <div class="flex flex-col items-center my-4">
-              <p>Kadastro objekto pavadinimas: <b><%= item.extendedData?.pavadinimas || item.name || '' %></b></p>
+              <p class="text-xl">Kadastro objekto pavadinimas: <b><%= item.extendedData?.pavadinimas || item.name || '' %></b></p>
               <% if (item.extendedData?.kadastroId || item.cadastralId) { %>
                 <p>Identifikavimo kodas: <b><%= item.extendedData?.kadastroId || item.cadastralId %></b></p>
               <% } %>


### PR DESCRIPTION
## Summary
Re-add \`text-xl\` to the relabelled \`Kadastro objekto pavadinimas: <name>\` line. PR #103 swapped \`<p class="font-bold text-xl">Novena</p>\` for \`<p>Kadastro objekto pavadinimas: <b>Novena</b></p>\` and dropped the size class with it, so the PDF read visibly smaller than before.

## Test plan
- [ ] Regenerate extract for a RIVER object (Novena / cadastralId=12110006) → name line is the same XL size as before, not body-text size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)