### PR TITLE
extract screenshot: serialize jobs (concurrency 5 -> 1) to avoid label overlap

### DIFF
--- a/services/jobs.service.ts
+++ b/services/jobs.service.ts
@@ -11,7 +11,15 @@ import moment from 'moment';
   mixins: [BullMqMixin],
   settings: {
     bullmq: {
-      worker: { concurrency: 5 },
+      // Serialize screenshot jobs (1, not 5) because multi-object request
+      // extracts were rendering duplicated map labels — same WMS basin /
+      // cadastral labels appearing twice, slightly offset. Upstream
+      // biip-tools /screenshot is a thin proxy to the Chrome API
+      // (CHROME_API_ENDPOINT), and parallel calls into that service
+      // bleed OpenLayers ImageWMS tile state across pooled puppeteer
+      // pages. Sequential screenshots eliminate the overlap. Bump back
+      // up once the Chrome service is fixed to isolate page contexts.
+      worker: { concurrency: 1 },
       job: {
         attempts: 10,
         backoff: 1000,


### PR DESCRIPTION
## Why
Multi-object request extracts render with duplicated map labels — same WMS basin / cadastral text overlaid twice with a small offset. Single-object extracts are fine.

## Root cause (suspected)
- \`jobs.service.ts:14\` has \`concurrency: 5\` → up to 5 \`saveScreenshot\` jobs run in parallel per uetk-api instance.
- \`biip-tools/screenshot.service.ts:121\` is a thin proxy to the upstream Chrome API (\`CHROME_API_ENDPOINT\`).
- Parallel calls into that Chrome service appear to bleed OpenLayers ImageWMS tile state across pooled puppeteer pages — one request's layer tiles overlay the next.

## Fix
Drop screenshot worker concurrency from 5 → 1 so jobs run sequentially per uetk-api instance. Trade-off: multi-object extracts take longer (was N parallel, now N sequential), but no more overlap.

## Follow-up
Root-cause the Chrome service page-pool isolation separately. Once pages are isolated per request, bump concurrency back to 5.

## Test plan
- [ ] Multi-object request extract (≥3 objects) on staging → each PDF map page is clean (no duplicated labels).
- [ ] Single-object extract still works.
- [ ] Confirm generation completes (slower, but completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)