### PR TITLE
extract PDF: show name + ID header above map for every UETK object type

### DIFF
--- a/templates/request.ejs
+++ b/templates/request.ejs
@@ -156,10 +156,14 @@
             <p>Išrašo unikalus numeris <b><%= id %></b>, suformavimo data <b><%= formatDate(new Date()) %></b></p>
           </div>
           <hr />
-          <% if (['RIVER', 'CANAL'].includes(item.category)) { %>
+          <% var isHydroStructure = ['EARTH_DAM', 'WATER_EXCESS_CULVERT', 'HYDRO_POWER_PLANT', 'FISH_PASS'].includes(item.category); %>
+          <% var isWaterBody = ['RIVER', 'CANAL', 'NATURAL_LAKE', 'PONDED_LAKE', 'POND', 'ISOLATED_WATER_BODY', 'INTERMEDIATE_WATER_BODY', 'TERRITORIAL_WATER_BODY'].includes(item.category); %>
+          <% if (isWaterBody || isHydroStructure) { %>
             <div class="flex flex-col items-center my-4">
-              <p class="text-xl">Kadastro objekto pavadinimas: <b><%= item.extendedData?.pavadinimas || item.name || '' %></b></p>
-              <% if (item.extendedData?.kadastroId || item.cadastralId) { %>
+              <p class="text-xl">Pavadinimas: <b><%= item.extendedData?.pavadinimas || item.name || '' %></b></p>
+              <% if (isHydroStructure && item.extendedData?.hidrostatinioKodas) { %>
+                <p>Hidrotechninio statinio kodas: <b><%= item.extendedData.hidrostatinioKodas %></b></p>
+              <% } else if (item.extendedData?.kadastroId || item.cadastralId) { %>
                 <p>Identifikavimo kodas: <b><%= item.extendedData?.kadastroId || item.cadastralId %></b></p>
               <% } %>
             </div>


### PR DESCRIPTION
## Summary
Previously only \`RIVER\`/\`CANAL\` objects got a name header above the map screenshot. Lakes, ponds, isolated/intermediate/territorial water bodies, and the four hydro-structure categories (EARTH_DAM, WATER_EXCESS_CULVERT, HYDRO_POWER_PLANT, FISH_PASS) rendered the map cold.

## Changes
- Show the name+ID block for **all eight water-body** categories and the **four hydro-structure** categories.
- Label is now \`Pavadinimas:\` (was \`Kadastro objekto pavadinimas:\` — matches the cover-page object table).
- For hydro-structures: \`Hidrotechninio statinio kodas: <hidrostatinioKodas>\` instead of \`Identifikavimo kodas: <kadastroId>\`.

## Test plan
- [ ] RIVER (Novena / cadastralId=12110006) → \`Pavadinimas: Novena\` + \`Identifikavimo kodas: 12110006\`.
- [ ] NATURAL_LAKE / POND object → same shape with cadastralId.
- [ ] HYDRO_POWER_PLANT (e.g. Kauno HE) → \`Pavadinimas: Kauno HE\` + \`Hidrotechninio statinio kodas: 10010001h0001\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)